### PR TITLE
fs-4533 adding fix_default_page_ids to clone round

### DIFF
--- a/app/db/queries/application.py
+++ b/app/db/queries/application.py
@@ -122,6 +122,7 @@ def clone_single_section(section_id: str, new_round_id=None) -> Section:
         cloned_forms.append(cloned_form)
 
     db.session.add_all([clone, *cloned_forms, *cloned_pages, *cloned_components])
+    cloned_pages = _fix_cloned_default_pages(cloned_pages)
     db.session.commit()
 
     return clone


### PR DESCRIPTION
### Change description
Fixes a bug whereby if you clone an entire round it wasn't updating the `default_next_page_id` column of the cloned pages. Fixed this and updated unit tests

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
- Clone a round that contains forms
- Use 'View all application questions' to view the whole application and it should work (previously failing)


### Screenshots of UI changes (if applicable)
