### PR TITLE
fs-4642 adding cascade deletes

### DIFF
--- a/app/db/queries/application.py
+++ b/app/db/queries/application.py
@@ -1,5 +1,7 @@
 from uuid import uuid4
 
+from sqlalchemy import delete
+
 from app.db import db
 from app.db.models import Component
 from app.db.models import Form
@@ -283,8 +285,12 @@ def update_section(section_id, new_section_config):
     return section
 
 
-def delete_section(section_id):
+def delete_section(section_id, cascade: bool = False):
     section = db.session.query(Section).where(Section.section_id == section_id).one_or_none()
+    if cascade:
+        _delete_all_components_in_pages(page_ids=[page.page_id for form in section.forms for page in form.pages])
+        _delete_all_pages_in_forms(form_ids=[f.form_id for f in section.forms])
+        _delete_all_forms_in_sections(section_ids=[section_id])
     db.session.delete(section)
     db.session.commit()
     return section
@@ -351,8 +357,17 @@ def update_form(form_id, new_form_config):
     return form
 
 
-def delete_form(form_id):
+def _delete_all_forms_in_sections(section_ids: list):
+    stmt = delete(Form).filter(Form.section_id.in_(section_ids))
+    db.session.execute(stmt)
+    db.session.commit()
+
+
+def delete_form(form_id, cascade: bool = False):
     form = db.session.query(Form).where(Form.form_id == form_id).one_or_none()
+    if cascade:
+        _delete_all_components_in_pages(page_ids=[p.page_id for p in form.pages])
+        _delete_all_pages_in_forms(form_ids=[form_id])
     db.session.delete(form)
     db.session.commit()
     return form
@@ -419,8 +434,16 @@ def update_page(page_id, new_page_config):
     return page
 
 
-def delete_page(page_id):
+def _delete_all_pages_in_forms(form_ids: list):
+    stmt = delete(Page).filter(Page.form_id.in_(form_ids))
+    db.session.execute(stmt)
+    db.session.commit()
+
+
+def delete_page(page_id, cascade: bool = False):
     page = db.session.query(Page).where(Page.page_id == page_id).one_or_none()
+    if cascade:
+        _delete_all_components_in_pages(page_ids=[page_id])
     db.session.delete(page)
     db.session.commit()
     return page
@@ -516,3 +539,9 @@ def delete_component(component_id):
     db.session.delete(component)
     db.session.commit()
     return component
+
+
+def _delete_all_components_in_pages(page_ids):
+    stmt = delete(Component).filter(Component.page_id.in_(page_ids))
+    db.session.execute(stmt)
+    db.session.commit()

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -17,6 +17,7 @@ services:
       - DATABASE_URL=postgresql://postgres:password@fab-db:5432/fund_builder   # pragma: allowlist secret
       - FLASK_DEBUG=0
       - FLASK_ENV=development
+      - SECRET_KEY=local
     depends_on: [fab-db, form-runner]
 
   fab-db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     environment:
       - DATABASE_URL=postgresql://postgres:password@fab-db:5432/fab
       - DATABASE_URL_UNIT_TEST=postgresql://postgres:password@fab-db:5432/fab_unit_test
+      - SECRET_KEY=local
 
 
   fab-db:

--- a/tasks/db_tasks.py
+++ b/tasks/db_tasks.py
@@ -2,9 +2,11 @@ import os
 import sys
 from os import getenv
 
+from flask_migrate import upgrade
 from invoke import task  # noqa:E402
 
 from app import app
+from app.import_config.load_form_json import load_form_jsons
 
 sys.path.insert(1, ".")
 os.environ.update({"FLASK_ENV": "tasks"})
@@ -49,6 +51,7 @@ def recreate_local_dbs(c):
             print(
                 f"{db_uri} db created...",
             )
+            upgrade()
 
 
 @task
@@ -66,6 +69,7 @@ def create_test_data(c):
         )
         db.session.commit()
         insert_test_data(db=db, test_data=init_salmon_fishing_fund())
+        load_form_jsons()
 
 
 @task


### PR DESCRIPTION
### Change description
When editing an application round, the following now happens:
- If you delete a form from a section, the DB rows for that form, it's pages and components are also deleted
- If you delete a section from the application, then the forms within that section, and all their children are also deleted

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Create a round with multiple sections and forms within those sections
Delete a form and check it and its pages are deleted from the db
Delete a section and check it and it's forms are removed from the db


### Screenshots of UI changes (if applicable)
No UI changes as the behaviour was already present in the frontend but it was doing a soft delete so this change is backend only
