### PR TITLE
Fs 4643 numbering

### DIFF
--- a/.devcontainer/python-container/devcontainer.json
+++ b/.devcontainer/python-container/devcontainer.json
@@ -15,7 +15,9 @@
                 "ms-python.debugpy",
                 "ms-python.black-formatter",
                 "ms-python.isort",
-                "monosans.djlint"
+                "monosans.djlint",
+                "eamodio.gitlens",
+                "njpwerner.autodocstring"
             ]
         }
     }

--- a/app/blueprints/fund_builder/routes.py
+++ b/app/blueprints/fund_builder/routes.py
@@ -24,8 +24,8 @@ from app.db.models.fund import Fund
 from app.db.models.round import Round
 from app.db.queries.application import clone_single_form
 from app.db.queries.application import clone_single_round
-from app.db.queries.application import delete_form
-from app.db.queries.application import delete_section
+from app.db.queries.application import delete_form_from_section
+from app.db.queries.application import delete_section_from_round
 from app.db.queries.application import get_all_template_forms
 from app.db.queries.application import get_form_by_id
 from app.db.queries.application import get_section_by_id
@@ -73,7 +73,7 @@ def section(round_id):
     }
     existing_section = None
     if request.args.get("action") == "remove":
-        delete_section(section_id=request.args.get("section_id"), cascade=True)
+        delete_section_from_round(round_id=round_id, section_id=request.args.get("section_id"), cascade=True)
         return redirect(url_for("build_fund_bp.build_application", round_id=round_id))
     if form.validate_on_submit():
         count_existing_sections = len(round_obj.sections)
@@ -121,7 +121,7 @@ def configure_forms_in_section(round_id, section_id):
     if request.method == "POST":
         if request.args.get("action") == "remove":
             form_id = request.args.get("form_id")
-            delete_form(form_id=form_id, cascade=True)
+            delete_form_from_section(section_id=section_id, form_id=form_id, cascade=True)
         else:
             template_id = request.form.get("template_id")
             section = get_section_by_id(section_id=section_id)

--- a/app/blueprints/fund_builder/routes.py
+++ b/app/blueprints/fund_builder/routes.py
@@ -30,6 +30,8 @@ from app.db.queries.application import get_all_template_forms
 from app.db.queries.application import get_form_by_id
 from app.db.queries.application import get_section_by_id
 from app.db.queries.application import insert_new_section
+from app.db.queries.application import move_section_down
+from app.db.queries.application import move_section_up
 from app.db.queries.application import update_section
 from app.db.queries.fund import add_fund
 from app.db.queries.fund import get_all_funds
@@ -72,8 +74,15 @@ def section(round_id):
         "round_id": str(round_id),
     }
     existing_section = None
+    # TODO there must be a better way than a pile of ifs...
     if request.args.get("action") == "remove":
         delete_section_from_round(round_id=round_id, section_id=request.args.get("section_id"), cascade=True)
+        return redirect(url_for("build_fund_bp.build_application", round_id=round_id))
+    if request.args.get("action") == "move_up":
+        move_section_up(round_id=round_id, section_index_to_move_up=int(request.args.get("index")))
+        return redirect(url_for("build_fund_bp.build_application", round_id=round_id))
+    if request.args.get("action") == "move_down":
+        move_section_down(round_id=round_id, section_index_to_move_down=int(request.args.get("index")))
         return redirect(url_for("build_fund_bp.build_application", round_id=round_id))
     if form.validate_on_submit():
         count_existing_sections = len(round_obj.sections)

--- a/app/blueprints/fund_builder/routes.py
+++ b/app/blueprints/fund_builder/routes.py
@@ -30,6 +30,8 @@ from app.db.queries.application import get_all_template_forms
 from app.db.queries.application import get_form_by_id
 from app.db.queries.application import get_section_by_id
 from app.db.queries.application import insert_new_section
+from app.db.queries.application import move_form_down
+from app.db.queries.application import move_form_up
 from app.db.queries.application import move_section_down
 from app.db.queries.application import move_section_up
 from app.db.queries.application import update_section
@@ -125,17 +127,22 @@ def section(round_id):
     return render_template("section.html", form=form, **params)
 
 
-@build_fund_bp.route("/fund/round/<round_id>/section/<section_id>/forms", methods=["POST"])
+@build_fund_bp.route("/fund/round/<round_id>/section/<section_id>/forms", methods=["POST", "GET"])
 def configure_forms_in_section(round_id, section_id):
-    if request.method == "POST":
+    if request.method == "GET":
         if request.args.get("action") == "remove":
             form_id = request.args.get("form_id")
             delete_form_from_section(section_id=section_id, form_id=form_id, cascade=True)
-        else:
-            template_id = request.form.get("template_id")
-            section = get_section_by_id(section_id=section_id)
-            new_section_index = max(len(section.forms) + 1, 1)
-            clone_single_form(form_id=template_id, new_section_id=section_id, section_index=new_section_index)
+        if request.args.get("action") == "move_up":
+            move_form_up(section_id=section_id, form_index_to_move_up=int(request.args.get("index")))
+        if request.args.get("action") == "move_down":
+            move_form_down(section_id=section_id, form_index_to_move_down=int(request.args.get("index")))
+
+    if request.method == "POST":
+        template_id = request.form.get("template_id")
+        section = get_section_by_id(section_id=section_id)
+        new_section_index = max(len(section.forms) + 1, 1)
+        clone_single_form(form_id=template_id, new_section_id=section_id, section_index=new_section_index)
 
     return redirect(url_for("build_fund_bp.section", round_id=round_id, section_id=section_id))
 

--- a/app/blueprints/fund_builder/templates/build_application.html
+++ b/app/blueprints/fund_builder/templates/build_application.html
@@ -35,8 +35,14 @@
                     <h3 class="govuk-heading-m">{{ section.index }}. {{ section.name_in_apply_json["en"] }}</h3>
                 </span>
                 <span class="app-task-list__task-actions">
-                    <a href='{{ url_for("build_fund_bp.section", round_id=round.round_id, section_id=section.section_id) }}'>Edit</a>
-                    <a href='{{ url_for("build_fund_bp.section",round_id=round.round_id, section_id=section.section_id, action="remove") }}'>Remove</a>
+                    <a class="govuk-link--no-visited-state" href='{{ url_for("build_fund_bp.section", round_id=round.round_id, section_id=section.section_id) }}'>Edit</a>&nbsp;
+                    <a class="govuk-link--no-visited-state" href='{{ url_for("build_fund_bp.section",round_id=round.round_id, section_id=section.section_id, action="remove") }}'>Remove</a>&nbsp;
+                    {% if section.index > 1 %}
+                        <a class="govuk-link--no-visited-state" href='{{ url_for("build_fund_bp.section",round_id=round.round_id, index=section.index, action="move_up") }}'>Move up</a>&nbsp;
+                    {% endif %}
+                    {% if section.index < round.sections | length %}
+                        <a class="govuk-link--no-visited-state" href='{{ url_for("build_fund_bp.section",round_id=round.round_id, index=section.index, action="move_down") }}'> Move down</a>
+                    {% endif %}
                 </span>
                 <ul class="app-task-list__items">
                     {% for form in section.forms %}
@@ -47,9 +53,9 @@
                                 </h3>
                             </span>
                             <span class="app-task-list__task-actions">
-                                <a href="{{ url_for('build_fund_bp.view_form_questions', round_id=round.round_id, form_id=form.form_id) }}">View</a>&nbsp;
-                                <a href='{{ url_for("build_fund_bp.download_form_json", form_id=form.form_id) }}'>Download</a>&nbsp;
-                                <a href='{{ url_for("build_fund_bp.preview_form", form_id=form.form_id) }}'>Preview</a>&nbsp;
+                                <a class="govuk-link--no-visited-state" href="{{ url_for('build_fund_bp.view_form_questions', round_id=round.round_id, form_id=form.form_id) }}">View</a>&nbsp;
+                                <a class="govuk-link--no-visited-state" href='{{ url_for("build_fund_bp.download_form_json", form_id=form.form_id) }}'>Download</a>&nbsp;
+                                <a class="govuk-link--no-visited-state" href='{{ url_for("build_fund_bp.preview_form", form_id=form.form_id) }}'>Preview</a>&nbsp;
                             </span>
                         </li>
                     {% endfor %}

--- a/app/blueprints/fund_builder/templates/section.html
+++ b/app/blueprints/fund_builder/templates/section.html
@@ -4,49 +4,64 @@
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 {%- from "govuk_frontend_jinja/components/select/macro.html" import govukSelect -%}
 {% block content %}
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-        <h1 class="govuk-heading-l">{%if form.section_id.data %}Update{% else %}Create{%endif%}&nbsp;Section</h1>
-        <div class="govuk-form-group">
-            <fieldset class="govuk-fieldset">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <h1 class="govuk-heading-l">
+                {% if form.section_id.data %}
+                    Update
+                {% else %}
+                    Create{% endif %}&nbsp;Section
+                </h1>
                 <form method="POST">
-                    {{ form.hidden_tag()}}
-                    {{input(form.name_in_apply_en)}}
-
-                    {{ govukButton({
-                        "text": "Save"
-                        }) }}
+                    <div class="govuk-form-group">
+                        <h3 class="govuk-heading-m">Section Name</h3>
+                        {{ form.hidden_tag() }}
+                        {{ input(form.name_in_apply_en) }}
+                    </div>
+                    {{ govukButton({"text": "Save"}) }}
                 </form>
-            </fieldset>
+            </div>
         </div>
-    </div>
-</div>
-{%if form.section_id.data %}
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-        <h2 class="govuk-heading-m">Forms in this section</h2>
-        {% for app_form in forms_in_section %}
-        <form method="POST" action="{{url_for('build_fund_bp.configure_forms_in_section', round_id=round_id, section_id=app_form.section_id, form_id=app_form.form_id, action='remove')}}">
-            <span class="govuk-body">{{app_form.section_index}}&nbsp;{{app_form.name_in_apply_json["en"]}}</span>
-            {{govukButton({"text":"Remove","classes": "govuk-button--secondary"}) }}
-        </form>
-        {% endfor %}
-        <h3 class="govuk-heading-s">Add Form From Template</h3>
-        <form method="POST" action="{{url_for('build_fund_bp.configure_forms_in_section', round_id=round_id,section_id=form.section_id.data)}}">
-
-            {{ govukSelect({
-                "id": "template_id",
-                "name": "template_id",
-                "label": {
-                  "text": "Create form from template"
-                },
-                "items": available_template_forms})}}
-
-        {{ govukButton({
-            "text": "Add"
-            }) }}
-    </form>
-    </div>
-</div>
-{% endif %}
-{% endblock content %}
+        {% if form.section_id.data %}
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <span class="app-task-list__task-name">
+                        <h3 class="govuk-heading-m">Forms in this section</h3>
+                    </span>
+                    <ul class="app-task-list__items">
+                        {% for app_form in forms_in_section %}
+                            <li class="app-task-list__item task-list__new-design">
+                                <span class="app-task-list__task-name">
+                                    <h3 class="govuk-body">{{ app_form.section_index }}.&nbsp;{{ app_form.name_in_apply_json["en"] }}</h3>
+                                </span>
+                                <span class="app-task-list__task-actions">
+                                    <a class="govuk-link--no-visited-state"
+                                       href="{{ url_for('build_fund_bp.configure_forms_in_section', round_id=round_id, section_id=app_form.section_id, form_id=app_form.form_id, action='remove') }}">Remove</a>&nbsp;
+                                    {% if app_form.section_index > 1 %}
+                                        <a class="govuk-link--no-visited-state"
+                                           href="{{ url_for('build_fund_bp.configure_forms_in_section', round_id=round_id, section_id=app_form.section_id, index=app_form.section_index, action='move_up') }}">Move up</a>&nbsp;
+                                    {% endif %}
+                                    {% if app_form.section_index < forms_in_section | length %}
+                                        <a class="govuk-link--no-visited-state"
+                                           href="{{ url_for('build_fund_bp.configure_forms_in_section', round_id=round_id, section_id=app_form.section_id, index=app_form.section_index, action='move_down') }}"> Move down</a>
+                                    {% endif %}
+                                </span>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                    <h3 class="govuk-heading-m">Add Form From Template</h3>
+                    <form method="POST"
+                          action="{{ url_for('build_fund_bp.configure_forms_in_section', round_id=round_id,section_id=form.section_id.data) }}">
+                        {{ govukSelect({
+                                                "id": "template_id",
+                                                "name": "template_id",
+                                                "label": {
+                                                "text": "Create form from template"
+                                                },
+                                                "items": available_template_forms}) }}
+                        {{ govukButton({"text": "Add"}) }}
+                    </form>
+                </div>
+            </div>
+        {% endif %}
+    {% endblock content %}

--- a/app/db/models/application_config.py
+++ b/app/db/models/application_config.py
@@ -70,7 +70,7 @@ class Section(BaseModel):
     source_template_id = Column(UUID(as_uuid=True), nullable=True)
 
     def __repr__(self):
-        return f"Section([{self.section_id}], {self.name_in_apply_json['en']}, Forms: {self.forms})"
+        return f"Section({self.index}, {self.name_in_apply_json['en']} [{self.section_id}], Forms: {self.forms})"
 
     def as_dict(self, include_relationships=False):
         result = {col.name: getattr(self, col.name) for col in inspect(self).mapper.columns}
@@ -104,7 +104,10 @@ class Form(BaseModel):
     source_template_id = Column(UUID(as_uuid=True), nullable=True)
 
     def __repr__(self):
-        return f"Form({self.runner_publish_name} - {self.name_in_apply_json['en']}, Pages: {self.pages})"
+        return (
+            f"Form({self.section_index}, {self.runner_publish_name}"
+            + f"- {self.name_in_apply_json['en']}, Pages: {self.pages})"
+        )
 
     def as_dict(self, include_relationships=False):
         result = {col.name: getattr(self, col.name) for col in inspect(self).mapper.columns}

--- a/app/db/models/application_config.py
+++ b/app/db/models/application_config.py
@@ -61,7 +61,10 @@ class Section(BaseModel):
     is_template = Column(Boolean, default=False, nullable=False)
     audit_info = Column(JSON(none_as_null=True))
     forms: Mapped[List["Form"]] = relationship(
-        "Form", order_by="Form.section_index", collection_class=ordering_list("section_index"), passive_deletes="all"
+        "Form",
+        order_by="Form.section_index",
+        collection_class=ordering_list("section_index", count_from=1),
+        passive_deletes="all",
     )
     index = Column(Integer())
     source_template_id = Column(UUID(as_uuid=True), nullable=True)

--- a/app/db/models/round.py
+++ b/app/db/models/round.py
@@ -10,6 +10,7 @@ from sqlalchemy import UniqueConstraint
 from sqlalchemy import inspect
 from sqlalchemy.dialects.postgresql import JSON
 from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.ext.orderinglist import ordering_list
 from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import relationship
 from sqlalchemy.types import Boolean
@@ -48,7 +49,12 @@ class Round(BaseModel):
     is_template = Column(Boolean, default=False, nullable=False)
     source_template_id = Column(UUID(as_uuid=True), nullable=True)
     template_name = Column(String(), nullable=True)
-    sections: Mapped[list["Section"]] = relationship("Section")
+    sections: Mapped[list["Section"]] = relationship(
+        "Section",
+        order_by="Section.index",
+        collection_class=ordering_list("index", count_from=1),
+        passive_deletes="all",
+    )
     criteria: Mapped[list["Criteria"]] = relationship("Criteria")
     # several other fields to add
     application_reminder_sent = Column(Boolean, default=False, nullable=False)

--- a/app/db/queries/application.py
+++ b/app/db/queries/application.py
@@ -112,7 +112,7 @@ def clone_single_section(section_id: str, new_round_id=None) -> Section:
     cloned_components = []
     # loop through forms in this section and clone each one
     for form_to_clone in section_to_clone.forms:
-        cloned_form = _initiate_cloned_form(form_to_clone, clone.section_id)
+        cloned_form = _initiate_cloned_form(form_to_clone, clone.section_id, section_index=form_to_clone.section_index)
         # loop through pages in this section and clone each one
         for page_to_clone in form_to_clone.pages:
             cloned_page = _initiate_cloned_page(page_to_clone, new_form_id=cloned_form.form_id)

--- a/app/db/queries/application.py
+++ b/app/db/queries/application.py
@@ -615,6 +615,23 @@ def _delete_all_components_in_pages(page_ids):
 # Section and form reordering
 
 
+def swap_elements_in_list(containing_list: list, index_a: int, index_b: int) -> list:
+    """Swaps the elements at the specified indices in the supplied list.
+    If either index is outside the valid range, returns the list unchanged.
+
+    Args:
+        containing_list (list): List containing the elements to swap
+        index_a (int): List index (0-based) of the first element to swap
+        index_b (int): List index (0-based) of the second element to swap
+
+    Returns:
+        list: The updated list
+    """
+    if 0 <= index_a < len(containing_list) and 0 <= index_b < len(containing_list):
+        containing_list[index_a], containing_list[index_b] = containing_list[index_b], containing_list[index_a]
+    return containing_list
+
+
 def move_section_down(round_id, section_index_to_move_down: int):
     """Moves a section one place down in the ordered list of sections in a round.
     In this case down means visually down, so the index number will increase by 1.
@@ -636,13 +653,8 @@ def move_section_down(round_id, section_index_to_move_down: int):
         section_index_to_move_down (int): Current Section.index value of the section to move
     """
     round: Round = get_round_by_id(round_id)
-    if section_index_to_move_down >= len(round.sections):
-        raise IndexError("Cannot move the last section down")
     list_index_to_move_down = section_index_to_move_down - 1  # Need the 0-based index inside the list
-    # Remove the seciton we are moving from the list
-    moved_section = round.sections.pop(list_index_to_move_down)
-    # Reinsert it at the new position - because the list index is 0-based, this equates to the old Section.index
-    round.sections.insert(section_index_to_move_down, moved_section)
+    round.sections = swap_elements_in_list(round.sections, list_index_to_move_down, list_index_to_move_down + 1)
     db.session.commit()
 
 
@@ -670,12 +682,7 @@ def move_section_up(round_id, section_index_to_move_up: int):
 
     round: Round = get_round_by_id(round_id)
     list_index_to_move_up = section_index_to_move_up - 1  # Need the 0-based index inside the list
-    if section_index_to_move_up == 1:
-        raise IndexError("Cannot move the first section up")
-    # Remove the seciton we are moving from the list
-    moved_section = round.sections.pop(index=list_index_to_move_up)
-    # Reinsert it at the new position - because the list index is 0-based, this equates to the old Section.index
-    round.sections.insert(list_index_to_move_up - 1, moved_section)
+    round.sections = swap_elements_in_list(round.sections, list_index_to_move_up, list_index_to_move_up - 1)
 
     db.session.commit()
 
@@ -701,13 +708,9 @@ def move_form_down(section_id, form_index_to_move_down: int):
         form_index_to_move_down (int): Current Form.section_index value of the form to move
     """
     section: Section = get_section_by_id(section_id)
-    if form_index_to_move_down >= len(section.forms):
-        raise IndexError("Cannot move the last form down")
     list_index_to_move_down = form_index_to_move_down - 1  # Need the 0-based index inside the list
-    # Remove the form we are moving from the list
-    moved_form = section.forms.pop(list_index_to_move_down)
-    # Reinsert it at the new position - because the list index is 0-based, this equates to the old Form.index
-    section.forms.insert(form_index_to_move_down, moved_form)
+
+    section.forms = swap_elements_in_list(section.forms, list_index_to_move_down, list_index_to_move_down + 1)
     db.session.commit()
 
 
@@ -735,11 +738,6 @@ def move_form_up(section_id, form_index_to_move_up: int):
 
     section: Section = get_section_by_id(section_id)
     list_index_to_move_up = form_index_to_move_up - 1  # Need the 0-based index inside the list
-    if form_index_to_move_up == 1:
-        raise IndexError("Cannot move the first form up")
-    # Remove the form we are moving from the list
-    moved_form = section.forms.pop(index=list_index_to_move_up)
-    # Reinsert it at the new position - because the list index is 0-based, this equates to the old Form.section_index
-    section.forms.insert(list_index_to_move_up - 1, moved_form)
 
+    section.forms = swap_elements_in_list(section.forms, list_index_to_move_up, list_index_to_move_up - 1)
     db.session.commit()

--- a/app/db/queries/application.py
+++ b/app/db/queries/application.py
@@ -615,7 +615,7 @@ def _delete_all_components_in_pages(page_ids):
 # Section and form reordering
 
 
-def move_section_down(round_id, section_index_to_move_down):
+def move_section_down(round_id, section_index_to_move_down: int):
     """Moves a section one place down in the ordered list of sections in a round.
     In this case down means visually down, so the index number will increase by 1.
 
@@ -633,7 +633,7 @@ def move_section_down(round_id, section_index_to_move_down):
 
     Args:
         round_id (UUID): Round ID to move this section within
-        section_id_to_move_down (UUID): ID of the section to move down
+        section_index_to_move_down (int): Current Section.index value of the section to move
     """
     round: Round = get_round_by_id(round_id)
     if section_index_to_move_down >= len(round.sections):
@@ -646,7 +646,7 @@ def move_section_down(round_id, section_index_to_move_down):
     db.session.commit()
 
 
-def move_section_up(round_id, section_index_to_move_up):
+def move_section_up(round_id, section_index_to_move_up: int):
     """Moves a section one place up in the ordered list of sections in a round.
     In this case up means visually up, so the index number will decrease by 1.
 
@@ -665,7 +665,7 @@ def move_section_up(round_id, section_index_to_move_up):
 
     Args:
         round_id (UUID): Round ID to move this section within
-        section_id_to_move_down (UUID): ID of the section to move up
+        section_index_to_move_up (int): Current Section.index value of the section to move
     """
 
     round: Round = get_round_by_id(round_id)
@@ -676,5 +676,70 @@ def move_section_up(round_id, section_index_to_move_up):
     moved_section = round.sections.pop(index=list_index_to_move_up)
     # Reinsert it at the new position - because the list index is 0-based, this equates to the old Section.index
     round.sections.insert(list_index_to_move_up - 1, moved_section)
+
+    db.session.commit()
+
+
+def move_form_down(section_id, form_index_to_move_down: int):
+    """Moves a form one place down in the ordered list of forms in a section.
+    In this case down means visually down, so the index number will increase by 1.
+
+    Element | Form.section_index    | Index in list
+        A   |   1                   |   0
+        B   |   2                   |   1
+        C   |   3                   |   2
+
+    Then move B down, which results in C moving up
+
+    Element | Form.section_index    | Index in list
+        A   |   1                   |   0
+        C   |   2                   |   1
+        B   |   3                   |   2
+
+    Args:
+        section_id (UUID): Section ID to move this form within
+        form_index_to_move_down (int): Current Form.section_index value of the form to move
+    """
+    section: Section = get_section_by_id(section_id)
+    if form_index_to_move_down >= len(section.forms):
+        raise IndexError("Cannot move the last form down")
+    list_index_to_move_down = form_index_to_move_down - 1  # Need the 0-based index inside the list
+    # Remove the form we are moving from the list
+    moved_form = section.forms.pop(list_index_to_move_down)
+    # Reinsert it at the new position - because the list index is 0-based, this equates to the old Form.index
+    section.forms.insert(form_index_to_move_down, moved_form)
+    db.session.commit()
+
+
+def move_form_up(section_id, form_index_to_move_up: int):
+    """Moves a form one place up in the ordered list of forms in a section.
+    In this case up means visually up, so the index number will decrease by 1.
+
+
+    Element | Form.section_index    | Index in list
+        A   |   1                   |   0
+        B   |   2                   |   1
+        C   |   3                   |   2
+
+    Then move B up, which results in A moving down
+
+    Element | Form.section_index    | Index in list
+        B   |   1                   |   0
+        A   |   2                   |   1
+        C   |   3                   |   2
+
+    Args:
+        section_id (UUID): Section ID to move this form within
+        form_index_to_move_up (int): Current Form.section_index value of the form to up
+    """
+
+    section: Section = get_section_by_id(section_id)
+    list_index_to_move_up = form_index_to_move_up - 1  # Need the 0-based index inside the list
+    if form_index_to_move_up == 1:
+        raise IndexError("Cannot move the first form up")
+    # Remove the form we are moving from the list
+    moved_form = section.forms.pop(index=list_index_to_move_up)
+    # Reinsert it at the new position - because the list index is 0-based, this equates to the old Form.section_index
+    section.forms.insert(list_index_to_move_up - 1, moved_form)
 
     db.session.commit()

--- a/app/db/queries/application.py
+++ b/app/db/queries/application.py
@@ -312,7 +312,7 @@ def delete_section(section_id, cascade: bool = False):
     """Removes a section from the database. If cascade=True, will also cascade the delete
     to all forms within this section, and on down the hierarchy. This DOES NOT update
     numbering of any other sections in the round. If you want this, use
-    #delete_section_from_round() instead.
+    `.delete_section_from_round()` instead.
 
     Args:
         section_id (_type_): section ID to delete

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - DATABASE_URL=postgresql://postgres:password@fab-db:5432/fab
       - DATABASE_URL_UNIT_TEST=postgresql://postgres:password@fab-db:5432/fab_unit_test
       - SECRET_KEY=local
+      - FLASK_ENV=development
 
 
   fab-db:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -18,6 +18,7 @@ from app.db.queries.application import move_form_down
 from app.db.queries.application import move_form_up
 from app.db.queries.application import move_section_down
 from app.db.queries.application import move_section_up
+from app.db.queries.application import swap_elements_in_list
 from app.db.queries.fund import add_fund
 from app.db.queries.fund import add_organisation
 from app.db.queries.fund import get_all_funds
@@ -571,3 +572,19 @@ def test_move_form_down(seed_dynamic_data, _db, index_to_move, exp_new_index):
 
     assert updated_section.forms[index_to_move].form_id == id_to_move_down
     assert updated_section.forms[index_to_move - 1].form_id == id_to_move_up
+
+
+@pytest.mark.parametrize(
+    "input_list, idx_a, idx_b, exp_result",
+    [
+        (["a", "b", "c", "d"], 0, 1, ["b", "a", "c", "d"]),
+        (["a", "b", "c", "d"], 1, 3, ["a", "d", "c", "b"]),
+        (["a", "b", "c", "d"], -1, 3, ["a", "b", "c", "d"]),
+        (["a", "b", "c", "d"], -1, -123123, ["a", "b", "c", "d"]),
+        (["a", "b", "c", "d"], 1, -123123, ["a", "b", "c", "d"]),
+        (["a", "b", "c", "d"], 1, 4, ["a", "b", "c", "d"]),
+    ],
+)
+def test_swap_elements(input_list, idx_a, idx_b, exp_result):
+    result = swap_elements_in_list(input_list, idx_a, idx_b)
+    assert result == exp_result

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -292,7 +292,7 @@ def test_form_sorting(seed_dynamic_data, _db):
     assert result_section.forms[1].form_id == form1.form_id
     assert result_section.forms[2].form_id == formX.form_id
     assert result_section.forms[3].form_id == form2.form_id
-    assert result_section.forms[3].section_index == 3
+    assert result_section.forms[3].section_index == 4
 
 
 section_id = uuid4()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -10,6 +10,8 @@ from app.db.models import Organisation
 from app.db.models import Page
 from app.db.models import Round
 from app.db.models import Section
+from app.db.queries.application import delete_form_from_section
+from app.db.queries.application import delete_section_from_round
 from app.db.queries.application import get_template_page_by_display_path
 from app.db.queries.fund import add_fund
 from app.db.queries.fund import add_organisation
@@ -17,6 +19,8 @@ from app.db.queries.fund import get_all_funds
 from app.db.queries.fund import get_fund_by_id
 from app.db.queries.round import add_round
 from app.db.queries.round import get_round_by_id
+from tasks.test_data import BASIC_FUND_INFO
+from tasks.test_data import BASIC_ROUND_INFO
 
 
 def test_add_organisation(flask_test_client, _db, clear_test_data):
@@ -289,3 +293,77 @@ def test_form_sorting(seed_dynamic_data, _db):
     assert result_section.forms[2].form_id == formX.form_id
     assert result_section.forms[3].form_id == form2.form_id
     assert result_section.forms[3].section_index == 3
+
+
+section_id = uuid4()
+
+
+@pytest.mark.seed_config(
+    {
+        "sections": [Section(section_id=section_id, name_in_apply_json={"en": "hello section"})],
+        "forms": [
+            Form(form_id=uuid4(), section_id=section_id, section_index=1, name_in_apply_json={"en": "Form 1"}),
+            Form(form_id=uuid4(), section_id=section_id, section_index=2, name_in_apply_json={"en": "Form 2"}),
+            Form(form_id=uuid4(), section_id=section_id, section_index=3, name_in_apply_json={"en": "Form 3"}),
+        ],
+    }
+)
+def test_form_sorting_removal(seed_dynamic_data, _db):
+    section = seed_dynamic_data["sections"][0]
+
+    result_section: Section = _db.session.query(Section).where(Section.section_id == section.section_id).one_or_none()
+    assert len(result_section.forms) == 3
+    form2 = result_section.forms[1]
+    assert form2.section_index == 2
+
+    delete_form_from_section(section_id=result_section.section_id, form_id=form2.form_id)
+
+    updated_section: Section = _db.session.query(Section).where(Section.section_id == section.section_id).one_or_none()
+    assert len(updated_section.forms) == 2
+    assert updated_section.forms[0].section_index == 1
+    assert updated_section.forms[1].section_index == 2
+
+
+# Create a section with one form, at index 1
+round_id = uuid4()
+fund_id = uuid4()
+
+
+@pytest.mark.seed_config(
+    {
+        "funds": [Fund(**BASIC_FUND_INFO, fund_id=fund_id, short_name="UT1")],
+        "rounds": [Round(**BASIC_ROUND_INFO, round_id=round_id, fund_id=fund_id, short_name="R1")],
+        "sections": [
+            Section(
+                name_in_apply_json={
+                    "en": "hello section",
+                },
+                index=2,
+                round_id=round_id,
+            ),
+            Section(
+                name_in_apply_json={"en": "hello section2"},
+                index=2,
+                round_id=round_id,
+            ),
+            Section(
+                name_in_apply_json={"en": "hello section3"},
+                index=3,
+                round_id=round_id,
+            ),
+        ],
+    }
+)
+def test_section_sorting(seed_dynamic_data, _db):
+    round: Round = get_round_by_id(round_id)
+    assert len(round.sections) == 3
+    last_section_id = round.sections[2].section_id
+    assert round.sections[2].index == 3
+    section_to_delete = round.sections[1]
+
+    delete_section_from_round(section_id=section_to_delete.section_id, round_id=round_id)
+
+    updated_round = get_round_by_id(round_id)
+    assert len(updated_round.sections) == 2
+    assert round.sections[1].section_id == last_section_id
+    assert round.sections[1].index == 2

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -452,90 +452,6 @@ fund_id = uuid4()
         "sections": [
             Section(
                 name_in_apply_json={
-                    "en": "hello section",
-                },
-                index=1,
-                round_id=round_id,
-            ),
-            Section(
-                name_in_apply_json={"en": "hello section2"},
-                index=2,
-                round_id=round_id,
-            ),
-            Section(
-                name_in_apply_json={"en": "hello section3"},
-                index=3,
-                round_id=round_id,
-            ),
-        ],
-    }
-)
-def test_move_section_down_error(
-    seed_dynamic_data,
-    _db,
-):
-    round_id = seed_dynamic_data["rounds"][0].round_id
-    round: Round = get_round_by_id(round_id)
-    assert len(round.sections) == 3
-
-    index_to_move = 3
-    section_to_move_down = round.sections[index_to_move - 1]  # numbering starts at 1 not 0
-    assert section_to_move_down.index == index_to_move
-
-    # Attempt to move the last one in the list further down - should fail
-    with pytest.raises(IndexError):
-        move_section_down(round_id=round_id, section_index_to_move_down=index_to_move)
-
-
-@pytest.mark.seed_config(
-    {
-        "funds": [Fund(**BASIC_FUND_INFO, fund_id=fund_id, short_name="UT1")],
-        "rounds": [Round(**BASIC_ROUND_INFO, round_id=round_id, fund_id=fund_id, short_name="R1")],
-        "sections": [
-            Section(
-                name_in_apply_json={
-                    "en": "hello section",
-                },
-                index=1,
-                round_id=round_id,
-            ),
-            Section(
-                name_in_apply_json={"en": "hello section2"},
-                index=2,
-                round_id=round_id,
-            ),
-            Section(
-                name_in_apply_json={"en": "hello section3"},
-                index=3,
-                round_id=round_id,
-            ),
-        ],
-    }
-)
-def test_move_section_up_error(
-    seed_dynamic_data,
-    _db,
-):
-    round_id = seed_dynamic_data["rounds"][0].round_id
-    round: Round = get_round_by_id(round_id)
-    assert len(round.sections) == 3
-
-    index_to_move = 1
-    section_to_move_up = round.sections[index_to_move - 1]  # numbering starts at 1 not 0
-    assert section_to_move_up.index == index_to_move
-
-    # Attempt to move the first one in the list further up - should fail
-    with pytest.raises(IndexError):
-        move_section_up(round_id=round_id, section_index_to_move_up=index_to_move)
-
-
-@pytest.mark.seed_config(
-    {
-        "funds": [Fund(**BASIC_FUND_INFO, fund_id=fund_id, short_name="UT1")],
-        "rounds": [Round(**BASIC_ROUND_INFO, round_id=round_id, fund_id=fund_id, short_name="R1")],
-        "sections": [
-            Section(
-                name_in_apply_json={
                     "en": "section a",
                 },
                 index=1,
@@ -636,28 +552,6 @@ section_id = uuid4()
         ],
     }
 )
-def test_move_form_up_error(seed_dynamic_data, _db):
-    section_id = seed_dynamic_data["sections"][0].section_id
-    section = get_section_by_id(section_id)
-    assert len(section.forms) == 3
-
-    with pytest.raises(IndexError):
-        move_form_up(section_id, 1)
-
-
-section_id = uuid4()
-
-
-@pytest.mark.seed_config(
-    {
-        "sections": [Section(section_id=section_id, name_in_apply_json={"en": "hello section"})],
-        "forms": [
-            Form(form_id=uuid4(), section_id=section_id, section_index=1, name_in_apply_json={"en": "Form 1"}),
-            Form(form_id=uuid4(), section_id=section_id, section_index=2, name_in_apply_json={"en": "Form 2"}),
-            Form(form_id=uuid4(), section_id=section_id, section_index=3, name_in_apply_json={"en": "Form 3"}),
-        ],
-    }
-)
 @pytest.mark.parametrize("index_to_move, exp_new_index", [(1, 2), (2, 3)])
 def test_move_form_down(seed_dynamic_data, _db, index_to_move, exp_new_index):
     section_id = seed_dynamic_data["sections"][0].section_id
@@ -677,25 +571,3 @@ def test_move_form_down(seed_dynamic_data, _db, index_to_move, exp_new_index):
 
     assert updated_section.forms[index_to_move].form_id == id_to_move_down
     assert updated_section.forms[index_to_move - 1].form_id == id_to_move_up
-
-
-section_id = uuid4()
-
-
-@pytest.mark.seed_config(
-    {
-        "sections": [Section(section_id=section_id, name_in_apply_json={"en": "hello section"})],
-        "forms": [
-            Form(form_id=uuid4(), section_id=section_id, section_index=1, name_in_apply_json={"en": "Form 1"}),
-            Form(form_id=uuid4(), section_id=section_id, section_index=2, name_in_apply_json={"en": "Form 2"}),
-            Form(form_id=uuid4(), section_id=section_id, section_index=3, name_in_apply_json={"en": "Form 3"}),
-        ],
-    }
-)
-def test_move_form_down_error(seed_dynamic_data, _db):
-    section_id = seed_dynamic_data["sections"][0].section_id
-    section = get_section_by_id(section_id)
-    assert len(section.forms) == 3
-
-    with pytest.raises(IndexError):
-        move_form_down(section_id, 3)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -12,7 +12,10 @@ from app.db.models import Round
 from app.db.models import Section
 from app.db.queries.application import delete_form_from_section
 from app.db.queries.application import delete_section_from_round
+from app.db.queries.application import get_section_by_id
 from app.db.queries.application import get_template_page_by_display_path
+from app.db.queries.application import move_form_down
+from app.db.queries.application import move_form_up
 from app.db.queries.application import move_section_down
 from app.db.queries.application import move_section_up
 from app.db.queries.fund import add_fund
@@ -584,3 +587,115 @@ def test_move_section_up(seed_dynamic_data, _db, index_to_move, exp_new_index):
     moved_down_section = updated_round.sections[index_to_move - 1]
     assert moved_down_section.section_id == id_that_gets_moved_down
     assert moved_down_section.index == exp_new_index + 1
+
+
+section_id = uuid4()
+
+
+@pytest.mark.seed_config(
+    {
+        "sections": [Section(section_id=section_id, name_in_apply_json={"en": "hello section"})],
+        "forms": [
+            Form(form_id=uuid4(), section_id=section_id, section_index=1, name_in_apply_json={"en": "Form 1"}),
+            Form(form_id=uuid4(), section_id=section_id, section_index=2, name_in_apply_json={"en": "Form 2"}),
+            Form(form_id=uuid4(), section_id=section_id, section_index=3, name_in_apply_json={"en": "Form 3"}),
+        ],
+    }
+)
+@pytest.mark.parametrize("index_to_move, exp_new_index", [(2, 1), (3, 2)])
+def test_move_form_up(seed_dynamic_data, _db, index_to_move, exp_new_index):
+    section_id = seed_dynamic_data["sections"][0].section_id
+    section = get_section_by_id(section_id)
+    assert len(section.forms) == 3
+
+    id_to_move_up = section.forms[index_to_move - 1].form_id
+    assert section.forms[index_to_move - 1].section_index == index_to_move
+
+    id_to_move_down = section.forms[index_to_move - 2].form_id
+    assert section.forms[index_to_move - 2].section_index == exp_new_index
+
+    move_form_up(section_id, index_to_move)
+
+    updated_section = get_section_by_id(section_id)
+    assert len(updated_section.forms) == 3
+
+    assert updated_section.forms[index_to_move - 2].form_id == id_to_move_up
+    assert updated_section.forms[index_to_move - 1].form_id == id_to_move_down
+
+
+section_id = uuid4()
+
+
+@pytest.mark.seed_config(
+    {
+        "sections": [Section(section_id=section_id, name_in_apply_json={"en": "hello section"})],
+        "forms": [
+            Form(form_id=uuid4(), section_id=section_id, section_index=1, name_in_apply_json={"en": "Form 1"}),
+            Form(form_id=uuid4(), section_id=section_id, section_index=2, name_in_apply_json={"en": "Form 2"}),
+            Form(form_id=uuid4(), section_id=section_id, section_index=3, name_in_apply_json={"en": "Form 3"}),
+        ],
+    }
+)
+def test_move_form_up_error(seed_dynamic_data, _db):
+    section_id = seed_dynamic_data["sections"][0].section_id
+    section = get_section_by_id(section_id)
+    assert len(section.forms) == 3
+
+    with pytest.raises(IndexError):
+        move_form_up(section_id, 1)
+
+
+section_id = uuid4()
+
+
+@pytest.mark.seed_config(
+    {
+        "sections": [Section(section_id=section_id, name_in_apply_json={"en": "hello section"})],
+        "forms": [
+            Form(form_id=uuid4(), section_id=section_id, section_index=1, name_in_apply_json={"en": "Form 1"}),
+            Form(form_id=uuid4(), section_id=section_id, section_index=2, name_in_apply_json={"en": "Form 2"}),
+            Form(form_id=uuid4(), section_id=section_id, section_index=3, name_in_apply_json={"en": "Form 3"}),
+        ],
+    }
+)
+@pytest.mark.parametrize("index_to_move, exp_new_index", [(1, 2), (2, 3)])
+def test_move_form_down(seed_dynamic_data, _db, index_to_move, exp_new_index):
+    section_id = seed_dynamic_data["sections"][0].section_id
+    section = get_section_by_id(section_id)
+    assert len(section.forms) == 3
+
+    id_to_move_down = section.forms[index_to_move - 1].form_id
+    assert section.forms[index_to_move - 1].section_index == index_to_move
+
+    id_to_move_up = section.forms[index_to_move].form_id
+    assert section.forms[index_to_move].section_index == index_to_move + 1
+
+    move_form_down(section_id, index_to_move)
+
+    updated_section = get_section_by_id(section_id)
+    assert len(updated_section.forms) == 3
+
+    assert updated_section.forms[index_to_move].form_id == id_to_move_down
+    assert updated_section.forms[index_to_move - 1].form_id == id_to_move_up
+
+
+section_id = uuid4()
+
+
+@pytest.mark.seed_config(
+    {
+        "sections": [Section(section_id=section_id, name_in_apply_json={"en": "hello section"})],
+        "forms": [
+            Form(form_id=uuid4(), section_id=section_id, section_index=1, name_in_apply_json={"en": "Form 1"}),
+            Form(form_id=uuid4(), section_id=section_id, section_index=2, name_in_apply_json={"en": "Form 2"}),
+            Form(form_id=uuid4(), section_id=section_id, section_index=3, name_in_apply_json={"en": "Form 3"}),
+        ],
+    }
+)
+def test_move_form_down_error(seed_dynamic_data, _db):
+    section_id = seed_dynamic_data["sections"][0].section_id
+    section = get_section_by_id(section_id)
+    assert len(section.forms) == 3
+
+    with pytest.raises(IndexError):
+        move_form_down(section_id, 3)


### PR DESCRIPTION
### Change description
Allows the reordering of sections in a round and forms in a section. Also corrects the ordering of sections and forms when one is removed or cloned

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

### Screenshots of UI changes (if applicable)
Added move up/move down links to build application screen
![Screenshot 2024-09-25 at 12 26 57](https://github.com/user-attachments/assets/0855b841-a78a-4a10-8dfc-5ceeba42b9df)

Added move up/down links to section screen
![Screenshot 2024-09-25 at 12 27 39](https://github.com/user-attachments/assets/958ec905-e63b-4a58-9a59-cf0b6de353bb)

