### PR TITLE
Fs 4724 fix temp path

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+    "dockerComposeFile": [
+        "../docker-compose.yml",
+        "../compose.override.yml"
+    ],
+    "service": "fab",
+    "shutdownAction": "none",
+    "workspaceFolder": "/fab",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.debugpy",
+                "ms-python.vscode-pylance",
+                "mikoz.black-py"
+            ]
+        }
+    },
+}

--- a/app/blueprints/fund_builder/routes.py
+++ b/app/blueprints/fund_builder/routes.py
@@ -522,6 +522,14 @@ def view_form_questions(round_id, form_id):
         "view_questions.html", round=round, fund=fund, question_html=html, title=form.name_in_apply_json["en"]
     )
 
+def create_export_zip(directory_to_zip, zip_file_name) -> str:
+    # Output zip file path (temporary)
+    output_zip_path = Config.TEMP_FILE_PATH / zip_file_name
+
+    # Create a zip archive of the directory
+    shutil.make_archive(base_name=output_zip_path, format="zip", root_dir=directory_to_zip)
+    return f"{output_zip_path}.zip"
+
 
 @build_fund_bp.route("/create_export_files/<round_id>", methods=["GET"])
 def create_export_files(round_id):
@@ -530,13 +538,7 @@ def create_export_files(round_id):
     generate_config_for_round(round_id)
     round_short_name = get_round_by_id(round_id).short_name
 
-    # Directory to zip
-    directory_to_zip = Config.TEMP_FILE_PATH / "round_short_name"
-    # Output zip file path (temporary)
-    output_zip_path = Config.TEMP_FILE_PATH / f"{round_short_name}.zip"
-
-    # Create a zip archive of the directory
-    shutil.make_archive(output_zip_path.replace(".zip", ""), "zip", directory_to_zip)
+    output_zip_path = create_export_zip(directory_to_zip=Config.TEMP_FILE_PATH / round_short_name, zip_file_name=round_short_name)
 
     # Ensure the file is removed after sending it
     @after_this_request

--- a/app/blueprints/fund_builder/routes.py
+++ b/app/blueprints/fund_builder/routes.py
@@ -531,9 +531,9 @@ def create_export_files(round_id):
     round_short_name = get_round_by_id(round_id).short_name
 
     # Directory to zip
-    directory_to_zip = f"app/export_config/output/{round_short_name}/"
+    directory_to_zip = Config.TEMP_FILE_PATH / "round_short_name"
     # Output zip file path (temporary)
-    output_zip_path = f"app/export_config/output/{round_short_name}.zip"
+    output_zip_path = Config.TEMP_FILE_PATH / f"{round_short_name}.zip"
 
     # Create a zip archive of the directory
     shutil.make_archive(output_zip_path.replace(".zip", ""), "zip", directory_to_zip)

--- a/app/export_config/helpers.py
+++ b/app/export_config/helpers.py
@@ -7,29 +7,30 @@ from jsonschema import validate
 from app.blueprints.self_serve.routes import human_to_kebab_case
 from app.blueprints.self_serve.routes import human_to_snake_case
 from app.shared.helpers import convert_to_dict
+from config import Config
 
 
 def write_config(config, filename, round_short_name, config_type):
     # Get the directory of the current file
-    current_dir = os.path.dirname(__file__)
+    
 
     # Construct the path to the output directory relative to this file's location
-    base_output_dir = os.path.join(current_dir, f"output/{round_short_name}/")
+    base_output_dir = Config.TEMP_FILE_PATH / round_short_name
 
     if config_type == "form_json":
-        output_dir = os.path.join(base_output_dir, "form_runner/")
+        output_dir = base_output_dir/ "form_runner"
         content_to_write = config
-        file_path = os.path.join(output_dir, f"{human_to_kebab_case(filename)}.json")
+        file_path = output_dir/ f"{human_to_kebab_case(filename)}.json"
     elif config_type == "python_file":
-        output_dir = os.path.join(base_output_dir, "fund_store/")
+        output_dir = base_output_dir/ "fund_store"
         config_dict = convert_to_dict(config)  # Convert config to dict for non-JSON types
         content_to_write = "LOADER_CONFIG="
         content_to_write += str(config_dict)
-        file_path = os.path.join(output_dir, f"{human_to_snake_case(filename)}.py")
+        file_path = output_dir/ f"{human_to_snake_case(filename)}.py"
     elif config_type == "html":
-        output_dir = os.path.join(base_output_dir, "html/")
+        output_dir = base_output_dir/"html"
         content_to_write = config
-        file_path = os.path.join(output_dir, f"{filename}_all_questions_en.html")
+        file_path = output_dir/f"{filename}_all_questions_en.html"
 
     # Ensure the output directory exists
     os.makedirs(output_dir, exist_ok=True)

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -1,6 +1,7 @@
 import logging
 from os import environ
 from os import getenv
+from pathlib import Path
 
 from fsd_utils import CommonConfig
 from fsd_utils import configclass
@@ -19,4 +20,4 @@ class DefaultConfig(object):
     FORM_RUNNER_URL_REDIRECT = getenv("FORM_RUNNER_EXTERNAL_HOST", "http://localhost:3009")
     SQLALCHEMY_DATABASE_URI = environ.get("DATABASE_URL")
 
-    TEMP_FILE_PATH="/tmp"
+    TEMP_FILE_PATH=Path("/tmp")

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -18,3 +18,5 @@ class DefaultConfig(object):
     FORM_RUNNER_URL = getenv("FORM_RUNNER_INTERNAL_HOST", "http://form-runner:3009")
     FORM_RUNNER_URL_REDIRECT = getenv("FORM_RUNNER_EXTERNAL_HOST", "http://localhost:3009")
     SQLALCHEMY_DATABASE_URI = environ.get("DATABASE_URL")
+
+    TEMP_FILE_PATH="/tmp"

--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -1,5 +1,6 @@
 import logging
 from os import getenv
+from pathlib import Path
 
 from fsd_utils import configclass
 
@@ -16,3 +17,4 @@ class DevelopmentConfig(Config):
         "DATABASE_URL",
         "postgresql://postgres:password@fab-db:5432/fab",  # pragma: allowlist secret
     )
+    TEMP_FILE_PATH=Path("app") / "export_config" / "output"

--- a/config/envs/unit_test.py
+++ b/config/envs/unit_test.py
@@ -1,5 +1,6 @@
 import logging
 from os import getenv
+from pathlib import Path
 
 from fsd_utils import configclass
 
@@ -18,3 +19,4 @@ class UnitTestConfig(Config):
         "DATABASE_URL_UNIT_TEST",
         "postgresql://postgres:postgres@127.0.0.1:5432/fab_unit_test",  # pragma: allowlist secret
     )
+    TEMP_FILE_PATH=Path("app") / "export_config" / "output"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,18 @@ from tasks.test_data import insert_test_data
 from tests.helpers import create_test_fund
 from tests.helpers import create_test_organisation
 from tests.helpers import create_test_round
+from config import Config
+import shutil
 
 pytest_plugins = ["fsd_test_utils.fixtures.db_fixtures"]
 
+
+@pytest.fixture(scope="session")
+def temp_output_dir():
+    temp_dir = Config.TEMP_FILE_PATH
+    yield temp_dir
+    if temp_dir.exists():
+        shutil.rmtree(temp_dir)
 
 @pytest.fixture
 def test_fund(flask_test_client, _db, clear_test_data):

--- a/tests/test_config_export.py
+++ b/tests/test_config_export.py
@@ -13,8 +13,9 @@ from app.export_config.generate_fund_round_html import frontend_html_prefix
 from app.export_config.generate_fund_round_html import frontend_html_suffix
 from app.export_config.generate_fund_round_html import generate_all_round_html
 from app.export_config.helpers import validate_json
+from config import Config
 
-output_base_path = Path("app") / "export_config" / "output"
+output_base_path = Config.TEMP_FILE_PATH
 
 
 def read_data_from_output_file(file):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -28,6 +28,8 @@ from app.shared.data_classes import ConditionValue
 from tasks.test_data import BASIC_FUND_INFO
 from tasks.test_data import BASIC_ROUND_INFO
 
+from config import Config
+
 
 def test_build_form_json_no_conditions(seed_dynamic_data):
 
@@ -283,7 +285,7 @@ def test_list_relationship(seed_dynamic_data):
     assert result.lizt.name == "classifications_list"
 
 
-output_base_path = Path("app") / "export_config" / "output"
+output_base_path = Config.TEMP_FILE_PATH
 
 
 # add files in /test_data t orun the below test against each file


### PR DESCRIPTION
### Change description
FS-4724 was a bug where the export functionality didn't work on any AWS environments. We need to use a different path for writing the temp files to for creating the zip archive. Updated the file path to come from config rather than hard coded inside the app, using `/tmp` for deployed environments.
- Added a unit test to check zip creation
- Added a test fixture to cleanup the temp output dir and made existing tests use this

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Create a fund and round and build an application (or use an existing one)
Go to 'Create Export Files for Round' and this should generate a zip file to download

