### PR TITLE
Removing prod, tests that don't apply, and making name more accurate

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -1,5 +1,5 @@
 name: Deploy to AWS
-run-name: AWS Deploy ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Dev-Test-UAT-Prod' || 'Dev') }}
+run-name: ${{ github.event_name == 'workflow_dispatch' && format('Deploy to {0}', github.event.inputs.environment) || (github.ref == 'refs/heads/main' && 'Deploy to Test-UAT-Prod' || 'Build & Unit Test') }}
 
 on:
   workflow_dispatch:
@@ -12,22 +12,7 @@ on:
         - dev
         - test
         - uat
-        - prod
-      run_performance_tests:
-        required: false
-        default: false
-        type: boolean
-        description: Run performance tests
-      run_e2e_tests_assessment:
-        required: false
-        default: false
-        type: boolean
-        description: Run e2e tests (assessment)
-      run_e2e_tests_application:
-        required: false
-        default: true
-        type: boolean
-        description: Run e2e tests (application)
+      
   push:
     # Ignore README markdown and the docs folder
     # Only automatically deploy when something in the app or tests folder has changed
@@ -41,7 +26,6 @@ on:
       - 'requirements-dev.txt'
       - 'requirements.in'
       - 'requirements.txt'
-      - '.github/workflows/copilot_deploy.yml'
 
 jobs:
   setup:
@@ -78,21 +62,21 @@ jobs:
       version: sha-${{ github.sha }}
       db_name: fsd-fund-application-builder
 
-  post_dev_deploy_tests:
-    needs: dev_deploy
-    concurrency:
-      group: 'fsd-preaward-dev'
-      cancel-in-progress: false
-    secrets:
-      FSD_GH_APP_ID: ${{ secrets.FSD_GH_APP_ID }}
-      FSD_GH_APP_KEY: ${{ secrets.FSD_GH_APP_KEY }}
-    uses: communitiesuk/funding-service-design-workflows/.github/workflows/post-deploy.yml@main
-    with:
-      run_performance_tests: ${{ inputs.run_performance_tests || true }}
-      run_e2e_tests_assessment: ${{ inputs.run_e2e_tests_assessment || false }}
-      run_e2e_tests_application: ${{ inputs.run_e2e_tests_application || false }}
-      app_name: fund-application-builder
-      environment: dev
+  # post_dev_deploy_tests:
+  #   needs: dev_deploy
+  #   concurrency:
+  #     group: 'fsd-preaward-dev'
+  #     cancel-in-progress: false
+  #   secrets:
+  #     FSD_GH_APP_ID: ${{ secrets.FSD_GH_APP_ID }}
+  #     FSD_GH_APP_KEY: ${{ secrets.FSD_GH_APP_KEY }}
+  #   uses: communitiesuk/funding-service-design-workflows/.github/workflows/post-deploy.yml@main
+  #   with:
+  #     run_performance_tests: ${{ inputs.run_performance_tests || true }}
+  #     run_e2e_tests_assessment: ${{ inputs.run_e2e_tests_assessment || false }}
+  #     run_e2e_tests_application: ${{ inputs.run_e2e_tests_application || false }}
+  #     app_name: fund-application-builder
+  #     environment: dev
 
   test_deploy:
     needs: [ dev_deploy, post_dev_deploy_tests, paketo_build, setup ]
@@ -106,22 +90,22 @@ jobs:
       version: sha-${{ github.sha }}
       db_name: fsd-fund-application-builder
 
-  post_test_deploy_tests:
-    needs: test_deploy
-    if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'test') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') )}}
-    concurrency:
-      group: 'fsd-preaward-test'
-      cancel-in-progress: false
-    secrets:
-      FSD_GH_APP_ID: ${{ secrets.FSD_GH_APP_ID }}
-      FSD_GH_APP_KEY: ${{ secrets.FSD_GH_APP_KEY }}
-    uses: communitiesuk/funding-service-design-workflows/.github/workflows/post-deploy.yml@main
-    with:
-      run_performance_tests: ${{ inputs.run_performance_tests || false }}
-      run_e2e_tests_assessment: ${{ inputs.run_e2e_tests_assessment || false }}
-      run_e2e_tests_application: ${{ inputs.run_e2e_tests_application || true }}
-      app_name: fund-application-builder
-      environment: test
+  # post_test_deploy_tests:
+  #   needs: test_deploy
+  #   if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'test') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') )}}
+  #   concurrency:
+  #     group: 'fsd-preaward-test'
+  #     cancel-in-progress: false
+  #   secrets:
+  #     FSD_GH_APP_ID: ${{ secrets.FSD_GH_APP_ID }}
+  #     FSD_GH_APP_KEY: ${{ secrets.FSD_GH_APP_KEY }}
+  #   uses: communitiesuk/funding-service-design-workflows/.github/workflows/post-deploy.yml@main
+  #   with:
+  #     run_performance_tests: ${{ inputs.run_performance_tests || false }}
+  #     run_e2e_tests_assessment: ${{ inputs.run_e2e_tests_assessment || false }}
+  #     run_e2e_tests_application: ${{ inputs.run_e2e_tests_application || true }}
+  #     app_name: fund-application-builder
+  #     environment: test
 
   uat_deploy:
     needs: [ dev_deploy, post_dev_deploy_tests, test_deploy, post_test_deploy_tests, paketo_build, setup ]
@@ -135,31 +119,31 @@ jobs:
       version: sha-${{ github.sha }}
       db_name: fsd-fund-application-builder
 
-  post_uat_deploy_tests:
-    needs: uat_deploy
-    if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'uat') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') )}}
-    concurrency:
-      group: 'fsd-preaward-uat'
-      cancel-in-progress: false
-    secrets:
-      FSD_GH_APP_ID: ${{ secrets.FSD_GH_APP_ID }}
-      FSD_GH_APP_KEY: ${{ secrets.FSD_GH_APP_KEY }}
-    uses: communitiesuk/funding-service-design-workflows/.github/workflows/post-deploy.yml@main
-    with:
-      run_performance_tests: ${{ inputs.run_performance_tests || false }}
-      run_e2e_tests_assessment: ${{ inputs.run_e2e_tests_assessment || false }}
-      run_e2e_tests_application: ${{ inputs.run_e2e_tests_application || true }}
-      app_name: fund-application-builder
-      environment: uat
+  # post_uat_deploy_tests:
+  #   needs: uat_deploy
+  #   if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'uat') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') )}}
+  #   concurrency:
+  #     group: 'fsd-preaward-uat'
+  #     cancel-in-progress: false
+  #   secrets:
+  #     FSD_GH_APP_ID: ${{ secrets.FSD_GH_APP_ID }}
+  #     FSD_GH_APP_KEY: ${{ secrets.FSD_GH_APP_KEY }}
+  #   uses: communitiesuk/funding-service-design-workflows/.github/workflows/post-deploy.yml@main
+  #   with:
+  #     run_performance_tests: ${{ inputs.run_performance_tests || false }}
+  #     run_e2e_tests_assessment: ${{ inputs.run_e2e_tests_assessment || false }}
+  #     run_e2e_tests_application: ${{ inputs.run_e2e_tests_application || true }}
+  #     app_name: fund-application-builder
+  #     environment: uat
 
-  prod_deploy:
-    needs: [ dev_deploy, post_dev_deploy_tests, test_deploy, post_test_deploy_tests, uat_deploy, post_uat_deploy_tests, paketo_build, setup ]
-    if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'prod') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') )}}
-    uses: communitiesuk/funding-service-design-workflows/.github/workflows/standard-deploy.yml@main
-    secrets:
-      AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
-    with:
-      environment: prod
-      app_name: fund-application-builder
-      version: sha-${{ github.sha }}
-      db_name: fsd-fund-application-builder
+  # prod_deploy:
+  #   needs: [ dev_deploy, post_dev_deploy_tests, test_deploy, post_test_deploy_tests, uat_deploy, post_uat_deploy_tests, paketo_build, setup ]
+  #   if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'prod') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') )}}
+  #   uses: communitiesuk/funding-service-design-workflows/.github/workflows/standard-deploy.yml@main
+  #   secrets:
+  #     AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
+  #   with:
+  #     environment: prod
+  #     app_name: fund-application-builder
+  #     version: sha-${{ github.sha }}
+  #     db_name: fsd-fund-application-builder


### PR DESCRIPTION
Updates to the github actions file:
- Change run name to 'Build and Unit Test' instead of 'Dev Deploy' to match other apps, and because we aren't auto deploying to dev
- Commented out post deploy tests as they don't relate to FAB and hold things up if they fail as they are unrelated
- Commented out prod deploy and removed from options as we are a long way from prod so don't need it there atm