### PR TITLE
Fixing json export

### DIFF
--- a/app/blueprints/fund_builder/forms/round.py
+++ b/app/blueprints/fund_builder/forms/round.py
@@ -12,6 +12,17 @@ from wtforms.validators import URL
 from wtforms.validators import DataRequired
 from wtforms.validators import Length
 from wtforms.validators import ValidationError
+import json
+
+
+def validate_json_field(form, field):
+    str_content = field.data
+    if not str_content:
+        return
+    try:
+        json.loads(str_content)
+    except Exception as ex:
+        raise ValidationError(f"Content is not valid JSON. Underlying error: [{str(ex)}]")
 
 
 def get_datetime(form_field):
@@ -74,6 +85,9 @@ class DateInputForm(Form):
 
 
 class RoundForm(FlaskForm):
+
+    JSON_FIELD_HINT = "Valid json format, using double quotes, lowercase true/false"
+
     round_id = HiddenField("Round ID")
     fund_id = StringField("Fund", validators=[DataRequired()])
     title_en = StringField("Title (en)", validators=[DataRequired()])
@@ -91,7 +105,9 @@ class RoundForm(FlaskForm):
     prospectus_link = URLField("Prospectus Link", validators=[DataRequired(), URL()])
     privacy_notice_link = URLField("Privacy Notice Link", validators=[DataRequired(), URL()])
     application_reminder_sent = RadioField(choices=[("true", "Yes"), ("false", "No")], default="false")
-    contact_us_banner_en = TextAreaField("Contact Us Banner (en)", description="HTML to display to override the default 'Contact Us' page content")
+    contact_us_banner_en = TextAreaField(
+        "Contact Us Banner (en)", description="HTML to display to override the default 'Contact Us' page content"
+    )
     contact_us_banner_cy = TextAreaField("Contact Us Banner (cy)", description="Leave blank for English-only funds")
     reference_contact_page_over_email = RadioField(
         "Reference contact page over email", choices=[("true", "Yes"), ("false", "No")], default="false"
@@ -106,16 +122,24 @@ class RoundForm(FlaskForm):
     feedback_link = URLField("Feedback Link", validators=[DataRequired(), URL()])
     project_name_field_id = StringField("Project name field ID", validators=[DataRequired()])
     application_guidance_en = TextAreaField("Application Guidance (en)")
-    application_guidance_cy = TextAreaField("Application Guidance (cy)", description="Leave blank for English-only funds")
+    application_guidance_cy = TextAreaField(
+        "Application Guidance (cy)", description="Leave blank for English-only funds"
+    )
     guidance_url = URLField("Guidance link", validators=[DataRequired(), URL()])
     all_uploaded_documents_section_available = RadioField(choices=[("true", "Yes"), ("false", "No")], default="false")
     application_fields_download_available = RadioField(choices=[("true", "Yes"), ("false", "No")], default="false")
     display_logo_on_pdf_exports = RadioField(choices=[("true", "Yes"), ("false", "No")], default="false")
     mark_as_complete_enabled = RadioField(choices=[("true", "Yes"), ("false", "No")], default="false")
     is_expression_of_interest = RadioField(choices=[("true", "Yes"), ("false", "No")], default="false")
-    feedback_survey_config = TextAreaField("Feedback Survey")
+    feedback_survey_config = TextAreaField(
+        "Feedback Survey", validators=[validate_json_field], description=JSON_FIELD_HINT
+    )
     eligibility_config = RadioField(
         "Has eligibility config", choices=[("true", "Yes"), ("false", "No")], default="false"
     )
-    eoi_decision_schema_en = TextAreaField("EOI Decision schema (en)")
-    eoi_decision_schema_cy = TextAreaField("EOI Decision schema (cy)", description="Leave blank for English-only funds")
+    eoi_decision_schema_en = TextAreaField(
+        "EOI Decision schema (en)", validators=[validate_json_field], description=JSON_FIELD_HINT
+    )
+    eoi_decision_schema_cy = TextAreaField(
+        "EOI Decision schema (cy)", description="Leave blank for English-only funds", validators=[validate_json_field]
+    )

--- a/app/blueprints/fund_builder/routes.py
+++ b/app/blueprints/fund_builder/routes.py
@@ -295,6 +295,17 @@ def round(round_id=None):
     )
 
 
+def _convert_json_data_for_form(data) -> str:
+    if isinstance(data, dict):
+        return json.dumps(data)
+    return str(data)
+
+def _convert_form_data_to_json(data) -> dict:
+    if data:
+        return json.loads(data)
+    return {}
+
+
 def populate_form_with_round_data(round):
     """
     Populate a RoundForm with data from a Round object.
@@ -340,14 +351,14 @@ def populate_form_with_round_data(round):
         "display_logo_on_pdf_exports": "true" if round.display_logo_on_pdf_exports else "false",
         "mark_as_complete_enabled": "true" if round.mark_as_complete_enabled else "false",
         "is_expression_of_interest": "true" if round.is_expression_of_interest else "false",
-        "feedback_survey_config": round.feedback_survey_config,
+        "feedback_survey_config": _convert_json_data_for_form(round.feedback_survey_config),
         "eligibility_config": (
             "true"
             if round.eligibility_config and round.eligibility_config.get("has_eligibility", "") == "true"
             else "false"
         ),
-        "eoi_decision_schema_en": round.eoi_decision_schema.get("en", "") if round.eoi_decision_schema else "",
-        "eoi_decision_schema_cy": round.eoi_decision_schema.get("cy", "") if round.eoi_decision_schema else "",
+        "eoi_decision_schema_en": _convert_json_data_for_form(round.eoi_decision_schema.get("en", "")) if round.eoi_decision_schema else "",
+        "eoi_decision_schema_cy": _convert_json_data_for_form(round.eoi_decision_schema.get("cy", "")) if round.eoi_decision_schema else "",
     }
     return RoundForm(data=round_data)
 
@@ -361,7 +372,7 @@ def update_existing_round(round, form):
     """
     round.title_json = {"en": form.title_en.data or None, "cy": form.title_cy.data or None}
     round.short_name = form.short_name.data
-    round.feedback_survey_config = form.feedback_survey_config.data
+    round.feedback_survey_config = _convert_form_data_to_json(form.feedback_survey_config.data)
     round.opens = get_datetime(form.opens)
     round.deadline = get_datetime(form.deadline)
     round.assessment_start = get_datetime(form.assessment_start)
@@ -400,7 +411,7 @@ def update_existing_round(round, form):
     round.mark_as_complete_enabled = form.mark_as_complete_enabled.data == "true"
     round.is_expression_of_interest = form.is_expression_of_interest.data == "true"
     round.eligibility_config = {"has_eligibility": form.eligibility_config.data}
-    round.eoi_decision_schema = {"en": form.eoi_decision_schema_en.data or None, "cy": form.eoi_decision_schema_cy.data or None}
+    round.eoi_decision_schema = {"en": _convert_form_data_to_json(form.eoi_decision_schema_en.data), "cy": _convert_form_data_to_json(form.eoi_decision_schema_cy.data)}
     round.audit_info = {"user": "dummy_user", "timestamp": datetime.now().isoformat(), "action": "update"}
     update_round(round)
 
@@ -440,14 +451,9 @@ def create_new_round(form):
         display_logo_on_pdf_exports=form.display_logo_on_pdf_exports.data == "true",
         mark_as_complete_enabled=form.mark_as_complete_enabled.data == "true",
         is_expression_of_interest=form.is_expression_of_interest.data == "true",
-        feedback_survey_config={
-            "has_feedback_survey": form.feedback_survey_config.data,
-            "has_section_feedback": False,
-            "is_feedback_survey_optional": False,
-            "is_section_feedback_optional": False,
-        },
+        feedback_survey_config=_convert_form_data_to_json(form.feedback_survey_config.data),
         eligibility_config={"has_eligibility": form.eligibility_config.data},
-        eoi_decision_schema={"en": form.eoi_decision_schema_en.data or None, "cy": form.eoi_decision_schema_cy.data or None},
+        eoi_decision_schema={"en": _convert_form_data_to_json(form.eoi_decision_schema_en.data), "cy": _convert_form_data_to_json(form.eoi_decision_schema_cy.data)},
     )
     add_round(new_round)
 

--- a/tasks/test_data.py
+++ b/tasks/test_data.py
@@ -396,6 +396,7 @@ def init_unit_test_data() -> dict:
         feedback_link="http://www.google.com",
         project_name_field_id="12312312312",
         guidance_url="http://www.google.com",
+        feedback_survey_config={"has_survey": False}
     )
     # r2: Round = Round(
     #     round_id=uuid4(),

--- a/tests/test_config_export.py
+++ b/tests/test_config_export.py
@@ -87,7 +87,7 @@ def test_generate_config_for_round_valid_input(seed_dynamic_data, monkeypatch, t
                     "mark_as_complete_enabled": False,
                     "is_expression_of_interest": False,
                     "eoi_decision_schema": None,
-                    "feedback_survey_config": None,
+                    "feedback_survey_config": {"has_survey":False},
                     "eligibility_config": {"has_eligibility": False},
                     "title_json": {"en": "round the first"},
                     "contact_us_banner_json": None,

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -177,7 +177,6 @@ def test_update_existing_round(flask_test_client, seed_dynamic_data):
         "feedback_link": "http://example.com/feedback",
         "project_name_field_id": 1,
         "guidance_url": "http://example.com/guidance",
-        "test": "test",
         "feedback_survey_config": '{"has_survey": true}',
     }
 


### PR DESCRIPTION
### Change description
Fixing the handling of json fields in the round so they export correctly for fund-store

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Create or edit a round, observe `feedback_survey_config` and `eoi_decision_schema` are saved as valid json and can be edited as such


### Screenshots of UI changes (if applicable)
