### PR TITLE
changing export filename to fund_short_code

### DIFF
--- a/app/export_config/generate_fund_round_config.py
+++ b/app/export_config/generate_fund_round_config.py
@@ -172,4 +172,4 @@ def generate_config_for_round(round_id):
     round_display_config = generate_application_display_config(round_id)
     TEMPLATE_FUND_ROUND_EXPORT["sections_config"] = round_display_config
     fund_round_export = TEMPLATE_FUND_ROUND_EXPORT
-    write_config(fund_round_export, "round_config", fund_round_export["round_config"]["short_name"], "python_file")
+    write_config(fund_round_export, fund_config["short_name"], fund_round_export["round_config"]["short_name"], "python_file")

--- a/tests/test_config_export.py
+++ b/tests/test_config_export.py
@@ -42,7 +42,7 @@ def test_generate_config_for_round_valid_input(seed_dynamic_data, monkeypatch, t
     # Assert: Check if the directory structure and files are created as expected
     expected_files = [
         {
-            "path": temp_output_dir / round_short_name / "fund_store" / "round_config.py",
+            "path": temp_output_dir / round_short_name / "fund_store" / f"{fund_short_name}.py",
             "expected_output": {
                 "sections_config": [
                     {


### PR DESCRIPTION
Updating the export filename for the fund_store config to use the fund_short_name as at the moment we need to manually rename this file for the fund loader