### PR TITLE
Bau add default assess config

### DIFF
--- a/app/export_config/generate_fund_round_config.py
+++ b/app/export_config/generate_fund_round_config.py
@@ -14,8 +14,10 @@ from app.shared.data_classes import FundExport
 from app.shared.data_classes import FundSectionForm
 from app.shared.data_classes import FundSectionSection
 from app.shared.data_classes import RoundExport
+from app.export_config import helpers
 from config import Config
 from app.all_questions.metadata_utils import form_json_to_assessment_display_types
+import json
 
 # TODO : The Round path might be better as a placeholder to avoid conflict in the actual fund store.
 # Decide on this further down the line.
@@ -244,40 +246,14 @@ def generate_default_assessment_mappings(fund_config, round_config):
                     theme["answers"].append(answer)
                 sc["themes"].append(theme)
             criteria["sub_criteria"].append(sc)
-
-    temp_assess_output = {
-        # Simple RECORD_OF_APPLICATION config for notify - uses the cof25 templates
-        "notfn_config": {
-            fund_id: {
-                "fund_name": fund_short_name,
-                "template_id": {
-                    "en": "6441da8a-1a42-4fe1-ad05-b7fb5f46a761",  # Using COF25 template
-                    "cy": "129490b8-4e35-4dc2-a8fb-bfd3be9e90d0",  # Using COF25 template
-                },
-            },
-        },
-        # all the following sections need adding to assessment-store
-        "fund_round_to_assessment_mapping": {
-            fund_round_ids: {
-                "schema_id": f"{fund_round}_assessment",
-                "unscored_sections": unscored,
-                "scored_criteria": scored,
-            },
-        },
-        "fund_round_data_key_mappings": {
-            fund_round: {
-                "location": None,
-                "asset_type": None,
-                "funding_one": None,
-                "funding_two": None,
-            },
-        },
-        "fund_round_mapping_config": {
-            fund_round: {
-                "fund_id": fund_id,
-                "round_id": round_id,
-                "type_of_application": str.upper(fund_short_name),
-            },
-        },
-    }
+    temp_assess_output = copy.deepcopy(helpers.temp_assess_output)
+    temp_assess_output = temp_assess_output.substitute(
+        fund_round=fund_round,
+        fund_id=fund_id,
+        round_id=round_id,
+        fund_round_ids=fund_round_ids,
+        fund_short_name=fund_short_name,
+        scored=json.dumps(scored),
+        unscored=json.dumps(unscored)
+    )
     write_config(temp_assess_output, "temp_assess", round_short_name, "temp_assess")

--- a/app/export_config/generate_fund_round_config.py
+++ b/app/export_config/generate_fund_round_config.py
@@ -202,10 +202,8 @@ def generate_default_assessment_mappings(fund_config, round_config):
 
     scored = []
     unscored = []
-    i = 0
     sections = db.session.query(Section).filter(Section.round_id == round_id).order_by(Section.index).all()
-    for section in sections:
-        i += 1
+    for i, section in enumerate(sections, start=1):
         type_of_criteria = "scored" if i % 2 == 0 else "unscored"  # do a random half scored and unscored
         criteria = {
             "id": human_to_kebab_case(section.name_in_apply_json["en"]),

--- a/app/export_config/helpers.py
+++ b/app/export_config/helpers.py
@@ -8,6 +8,7 @@ from app.blueprints.self_serve.routes import human_to_kebab_case
 from app.blueprints.self_serve.routes import human_to_snake_case
 from app.shared.helpers import convert_to_dict
 from config import Config
+from string import Template
 
 
 def write_config(config, filename, round_short_name, config_type):
@@ -36,7 +37,6 @@ def write_config(config, filename, round_short_name, config_type):
         content_to_write = str(config)
         file_path = output_dir / f"{human_to_snake_case(filename)}.py"
 
-
     # Ensure the output directory exists
     os.makedirs(output_dir, exist_ok=True)
 
@@ -62,3 +62,42 @@ def validate_json(data, schema):
         current_app.logger.error("Given JSON data is invalid")
         current_app.logger.error(err)
         return False
+
+
+temp_assess_output = Template(
+    """
+{
+    "notfn_config": {
+        "${fund_id}": {
+            "fund_name": "${fund_short_name}",
+            "template_id": {
+                "en": "6441da8a-1a42-4fe1-ad05-b7fb5f46a761",
+                "cy": "129490b8-4e35-4dc2-a8fb-bfd3be9e90d0",
+            },
+        },
+    },
+    "fund_round_to_assessment_mapping": {
+        "${fund_round_ids}": {
+            "schema_id": "${fund_round}_assessment",
+            "unscored_sections": ${unscored},
+            "scored_criteria": ${scored},
+        },
+    },
+    "fund_round_data_key_mappings": {
+        "${fund_round}": {
+            "location": None,
+            "asset_type": None,
+            "funding_one": None,
+            "funding_two": None,
+        },
+    },
+    "fund_round_mapping_config": {
+        "${fund_round}": {
+            "fund_id": "${fund_id}",
+            "round_id": "${round_id}",
+            "type_of_application": "${fund_short_name}",
+        },
+    },
+}
+"""
+)

--- a/app/export_config/helpers.py
+++ b/app/export_config/helpers.py
@@ -31,6 +31,12 @@ def write_config(config, filename, round_short_name, config_type):
         content_to_write = config
         file_path = output_dir / f"{filename}_all_questions_en.html"
 
+    elif config_type == "temp_assess":
+        output_dir = base_output_dir / "assessment_store"
+        content_to_write = str(config)
+        file_path = output_dir / f"{human_to_snake_case(filename)}.py"
+
+
     # Ensure the output directory exists
     os.makedirs(output_dir, exist_ok=True)
 
@@ -41,6 +47,8 @@ def write_config(config, filename, round_short_name, config_type):
         elif config_type == "python_file":
             print(content_to_write, file=f)  # Print the dictionary for non-JSON types
         elif config_type == "html":
+            f.write(content_to_write)
+        elif config_type == "temp_assess":
             f.write(content_to_write)
 
 

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -21,3 +21,4 @@ class DefaultConfig(object):
     SQLALCHEMY_DATABASE_URI = environ.get("DATABASE_URL")
 
     TEMP_FILE_PATH = Path("/tmp")
+    GENERATE_LOCAL_CONFIG = False

--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -18,3 +18,5 @@ class DevelopmentConfig(Config):
         "postgresql://postgres:password@fab-db:5432/fab",  # pragma: allowlist secret
     )
     TEMP_FILE_PATH = Path("app") / "export_config" / "output"
+
+    GENERATE_LOCAL_CONFIG = True

--- a/tests/test_config_export.py
+++ b/tests/test_config_export.py
@@ -42,7 +42,7 @@ def test_generate_config_for_round_valid_input(seed_dynamic_data, monkeypatch, t
     # Assert: Check if the directory structure and files are created as expected
     expected_files = [
         {
-            "path": temp_output_dir / round_short_name / "fund_store" / f"{fund_short_name}.py",
+            "path": temp_output_dir / round_short_name / "fund_store" / f"{str.lower(fund_short_name)}.py",
             "expected_output": {
                 "sections_config": [
                     {


### PR DESCRIPTION
Adding extra config to the export from fab:

- Includes notify config to send email on submit. Uses the existing templates from COF25 so it doesn't crash (otherwise we have to create new templates in notify for every local fund we have)

- Includes config for assessment store so the import process works:
- Generates the assessment mapping for scored and unscored criteria so that every field in the application appears in assessment. It makes each form a sub criteria and each page a theme. It alternates between scored and unscored. So whilst it's not suitable for production it will be useful for setting up local (or dummy) funds for testing.

Usage of this output detailed here: https://mhclgdigital.atlassian.net/wiki/spaces/FS/pages/336298006/Setting+up+fab+-+apply+-+assess+locally