### PR TITLE
Removing non existent target from compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ services:
   fab:
     build:
       context: .
-      target: fab-dev
       args:
         - USE_DEV_REQUIREMENTS=true
     volumes:


### PR DESCRIPTION
Changes to the Dockerfile to implement `uv` broke the dev container `docker-compose` file, so this removes the target that no longer exists.