### PR TITLE
BAU: Move application store api host to AWS parameter store secret

### DIFF
--- a/copilot/fsd-fund-application-builder/manifest.yml
+++ b/copilot/fsd-fund-application-builder/manifest.yml
@@ -47,7 +47,6 @@ network:
 variables:
   ACCOUNT_STORE_API_HOST: "http://fsd-account-store:8080"
   APPLICANT_fund-application-builder_HOST: "https://fund-application-builder.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
-  APPLICATION_STORE_API_HOST: "http://fsd-application-store:8080"
   AUTHENTICATOR_HOST: "https://authenticator.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
   COOKIE_DOMAIN: ".test.levellingup.gov.uk"
   FLASK_ENV: ${COPILOT_ENVIRONMENT_NAME}
@@ -60,6 +59,7 @@ secrets:
   RSA256_PUBLIC_KEY_BASE64: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/RSA256_PUBLIC_KEY_BASE64
   SECRET_KEY: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/SECRET_KEY
   FUND_STORE_API_HOST: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/FUND_STORE_API_HOST
+  APPLICATION_STORE_API_HOST: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/APPLICATION_STORE_API_HOST
 
 # You can override any of the values defined above by environment.
 environments:


### PR DESCRIPTION
### Change description
This will help us migrate from the "microservice"-y application-store to a more consolidated pre-award-stores service.

Ticket: https://mhclgdigital.atlassian.net/browse/FSPT-122