### PR TITLE
Turn off recreate deployment in test env

### DIFF
--- a/copilot/fsd-fund-application-builder/manifest.yml
+++ b/copilot/fsd-fund-application-builder/manifest.yml
@@ -67,8 +67,6 @@ environments:
     count:
       spot: 1
   test:
-    deployment:
-      rolling: "recreate"
     count:
       spot: 2
   uat:


### PR DESCRIPTION
This is because the `recreate` deployment method leads to downtime, which can cause tests to flake. It is not any faster than a normal deployment, and causes tests to break. I am not sure why it was chosen to begin with.

https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/#deployment-rolling