### PR TITLE
FS-4876 - Ensure all round fields are passed to the round export

### DIFF
--- a/app/export_config/generate_fund_round_config.py
+++ b/app/export_config/generate_fund_round_config.py
@@ -126,7 +126,7 @@ def generate_round_config(round_id):
         deadline=round.deadline.isoformat(),
         assessment_start=round.assessment_start.isoformat(),
         assessment_deadline=round.assessment_deadline.isoformat(),
-        application_reminder_sent=False,
+        application_reminder_sent=round.application_reminder_sent,
         reminder_date=round.reminder_date.isoformat(),
         prospectus=round.prospectus_link,
         privacy_notice=round.privacy_notice_link,
@@ -148,6 +148,7 @@ def generate_round_config(round_id):
         mark_as_complete_enabled=round.mark_as_complete_enabled,
         is_expression_of_interest=round.is_expression_of_interest,
         feedback_survey_config=round.feedback_survey_config,
+        eligibility_config=round.eligibility_config,
         eoi_decision_schema=round.eoi_decision_schema,
     )
 
@@ -180,7 +181,11 @@ def generate_config_for_round(round_id, base_output_dir=None):
     TEMPLATE_FUND_ROUND_EXPORT["sections_config"] = round_display_config
     fund_round_export = TEMPLATE_FUND_ROUND_EXPORT
     write_config(
-        fund_round_export, fund_config["short_name"], fund_round_export["round_config"]["short_name"], "python_file", base_output_dir
+        fund_round_export,
+        fund_config["short_name"],
+        fund_round_export["round_config"]["short_name"],
+        "python_file",
+        base_output_dir,
     )
 
     if Config.GENERATE_LOCAL_CONFIG:

--- a/tasks/test_data.py
+++ b/tasks/test_data.py
@@ -412,6 +412,7 @@ def init_unit_test_data() -> dict:
             "is_section_feedback_optional": False,
             "is_research_survey_optional": False,
         },
+        eligibility_config={"has_eligibility": False},
         eoi_decision_schema={"en": {"valid": True}, "cy": {"valid": False}},
     )
     # r2: Round = Round(


### PR DESCRIPTION
### Ticket

[Round fields not passed to export](https://mhclgdigital.atlassian.net/browse/FS-4876)

### Description

We noticed a bug whereby certain fields specified in the “Create a round” page of FAB are saved, but not passed to the export. This means that FAB-configured values for these values will have no effect in live services.

Specifically, the fields application_reminder_sent and eligibility_config are not exported.