### PR TITLE
FS-4877 - Fix local testing of FAB when using global Docker runner

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -25,7 +25,7 @@ jobs:
     uses: communitiesuk/funding-service-design-workflows/.github/workflows/pre-deploy.yml@main
     with:
       postgres_unit_testing: true
-      db_name: fab_unit_test
+      db_name: fab_store_test
 
   paketo_build:
     needs: [ setup ]

--- a/config/envs/unit_test.py
+++ b/config/envs/unit_test.py
@@ -16,7 +16,7 @@ class UnitTestConfig(Config):
     SECRET_KEY = "unit_test"  # pragma: allowlist secret
 
     SQLALCHEMY_DATABASE_URI = getenv(
-        "DATABASE_URL_UNIT_TEST",
-        "postgresql://postgres:postgres@127.0.0.1:5432/fab_unit_test",  # pragma: allowlist secret
+        "DATABASE_URL_TEST",
+        "postgresql://postgres:postgres@127.0.0.1:5432/fab_store_test",  # pragma: allowlist secret
     )
     TEMP_FILE_PATH = Path("app") / "export_config" / "output"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     command: sleep infinity
     environment:
       - DATABASE_URL=postgresql://postgres:password@fab-db:5432/fab
-      - DATABASE_URL_UNIT_TEST=postgresql://postgres:password@fab-db:5432/fab_unit_test
+      - DATABASE_URL_TEST=postgresql://postgres:password@fab-db:5432/fab_store_test
       - SECRET_KEY=local
       - FLASK_ENV=development
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -6,7 +6,7 @@ The database schema is defined in [app/db/models.py](./app/db/models.py) and is 
 See [Here](./app/db/database_ERD_9-8-24.png)
 
 ### Recreate Local DBs
-For both `DATABASE_URL` and `DATABASE_URL_UNIT_TEST`, drops the database if it exists and then recreates it.
+For both `DATABASE_URL` and `DATABASE_URL_TEST`, drops the database if it exists and then recreates it.
 
 ### Init migrations
 Deletes the [versions](./app/db/migrations/versions/) directory and runs `migrate()` to generate a new intial migration version for the SQLAlchemy models.

--- a/docs/run.md
+++ b/docs/run.md
@@ -6,7 +6,7 @@ This repo contains a devcontainer spec for VS code at [.devcontainer](.devcontai
 If developing locally, you will need a postgres instance running and to set the following environment variables:
  - `DATABASE_URL` to a suitable connection string. The default used is
  `postgresql://postgres:password@fab-db:5432/fund_builder`.   # pragma: allowlist secret
- - `DATABASE_URL_UNIT_TEST` default
+ - `DATABASE_URL_TEST` default
  `postgresql://postgres:password@fab-db:5432/fund_builder_unit_test`  # pragma: allowlist secret
 
 ## General

--- a/tasks/db_tasks.py
+++ b/tasks/db_tasks.py
@@ -34,8 +34,8 @@ def recreate_local_dbs(c):
             "postgresql://postgres:password@fab-db:5432/fab",  # pragma: allowlist secret
         ),
         getenv(
-            "DATABASE_URL_UNIT_TEST",
-            "postgresql://postgres:password@fab-db:5432/fab_unit_test",  # pragma: allowlist secret
+            "DATABASE_URL_TEST",
+            "postgresql://postgres:password@fab-db:5432/fab_store_test",  # pragma: allowlist secret
         ),
     ]
     with app.app_context():


### PR DESCRIPTION
### Ticket

[Fix local testing of FAB when using global Docker Runner](https://mhclgdigital.atlassian.net/browse/FS-4877)

### Description

Currently if we use the Funding Service-wide Docker runner to spin up apps locally, we get SQL connection issues when we try to run unit tests in FAB (uv run pytest .). This is because  these unit tests rely on the existence of a database fab_unit_test the global Docker Runner doesn’t provide this.

These changes are to rename from `fab_unit_test` to `fab_store_test` for consistency with the database name specified in [this PR](https://github.com/communitiesuk/funding-service-design-docker-runner/pull/100) and to change the environment variable name `DATABASE_URL_UNIT_TEST` to `DATABASE_URL_TEST` again for consistency with the database name and purpose.