### PR TITLE
FS-4877 - Ensuring FAB unit tests run both locally and in GitHub

### DIFF
--- a/config/envs/unit_test.py
+++ b/config/envs/unit_test.py
@@ -16,7 +16,7 @@ class UnitTestConfig(Config):
     SECRET_KEY = "unit_test"  # pragma: allowlist secret
 
     SQLALCHEMY_DATABASE_URI = getenv(
-        "DATABASE_URL_TEST",
-        "postgresql://postgres:postgres@127.0.0.1:5432/fab_store_test",  # pragma: allowlist secret
+        "DATABASE_URL",
+        "postgresql://postgres:password@127.0.0.1:5432/fab_store_test",  # pragma: allowlist secret
     )
     TEMP_FILE_PATH = Path("app") / "export_config" / "output"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
     command: sleep infinity
     environment:
       - DATABASE_URL=postgresql://postgres:password@fab-db:5432/fab
-      - DATABASE_URL_TEST=postgresql://postgres:password@fab-db:5432/fab_store_test
       - SECRET_KEY=local
       - FLASK_ENV=development
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -5,8 +5,8 @@ The database schema is defined in [app/db/models.py](./app/db/models.py) and is 
 ### Entity Relationship Diagram
 See [Here](./app/db/database_ERD_9-8-24.png)
 
-### Recreate Local DBs
-For both `DATABASE_URL` and `DATABASE_URL_TEST`, drops the database if it exists and then recreates it.
+### Recreate Local DB
+For `DATABASE_URL`, drop the database if it exists and then recreate it.
 
 ### Init migrations
 Deletes the [versions](./app/db/migrations/versions/) directory and runs `migrate()` to generate a new intial migration version for the SQLAlchemy models.

--- a/docs/run.md
+++ b/docs/run.md
@@ -6,8 +6,6 @@ This repo contains a devcontainer spec for VS code at [.devcontainer](.devcontai
 If developing locally, you will need a postgres instance running and to set the following environment variables:
  - `DATABASE_URL` to a suitable connection string. The default used is
  `postgresql://postgres:password@fab-db:5432/fund_builder`.   # pragma: allowlist secret
- - `DATABASE_URL_TEST` default
- `postgresql://postgres:password@fab-db:5432/fund_builder_unit_test`  # pragma: allowlist secret
 
 ## General
 Run the app with `flask run` (include `--debug` for auto reloading on file changes)

--- a/tasks/db_tasks.py
+++ b/tasks/db_tasks.py
@@ -28,31 +28,24 @@ def recreate_local_dbs(c):
     from sqlalchemy_utils.functions import database_exists
     from sqlalchemy_utils.functions import drop_database
 
-    uris = [
-        getenv(
-            "DATABASE_URL",
-            "postgresql://postgres:password@fab-db:5432/fab",  # pragma: allowlist secret
-        ),
-        getenv(
-            "DATABASE_URL_TEST",
-            "postgresql://postgres:password@fab-db:5432/fab_store_test",  # pragma: allowlist secret
-        ),
-    ]
+    db_uri = getenv(
+        "DATABASE_URL",
+        "postgresql://postgres:password@fab-db:5432/fab",  # pragma: allowlist secret
+    )
     with app.app_context():
-        for db_uri in uris:
-            if database_exists(db_uri):
-                print("Existing database found!\n")
-                drop_database(db_uri)
-                print("Existing database dropped!\n")
-            else:
-                print(
-                    f"{db_uri} not found...",
-                )
-            create_database(db_uri)
+        if database_exists(db_uri):
+            print("Existing database found!\n")
+            drop_database(db_uri)
+            print("Existing database dropped!\n")
+        else:
             print(
-                f"{db_uri} db created...",
+                f"{db_uri} not found...",
             )
-            upgrade()
+        create_database(db_uri)
+        print(
+            f"{db_uri} db created...",
+        )
+        upgrade()
 
 
 @task


### PR DESCRIPTION
### Ticket

[Fix local testing of FAB when using global Docker Runner](https://mhclgdigital.atlassian.net/browse/FS-4877)

### Description

This PR - https://github.com/communitiesuk/funding-service-design-fund-application-builder/pull/130 - was intended to fix this problem, but it did not. This is because of a discrepancy between the database password required for locally running unit tests versus running them in GitHub. I ran the tests locally with the password `password` which worked, then pushed the code up. The code failed in GitHub, so I changed the password to `postgres`, forgot to re-test and pushed the code up, which then passed on GitHub, then merged 🤓 

Anyway this PR fixes that by using an env var `DATABASE_URL` where available (containing the password `postgres`) and a hard-coded string containing the password `password` otherwise. This works because when running unit tests as part of the GitHub push workflow, we [inject DATABASE_URL]( https://github.com/communitiesuk/funding-service-design-workflows/blob/main/.github/workflows/pre-deploy.yml#L97-L100), providing a GitHub-compatible password, while when running locally, we have no env var set and so default to the locally-compatible connection string.