### PR TITLE
FS-4882: Fix for duplicate condition creation when the same condition

### DIFF
--- a/app/import_config/load_form_json.py
+++ b/app/import_config/load_form_json.py
@@ -115,12 +115,15 @@ def add_conditions_to_components(db, page: dict, conditions: dict, page_id):
 
                     # Add the new condition to the conditions list of the component to update
                     if component_to_update.conditions:
-                        component_to_update.conditions.append(asdict(new_condition))
-                        # Mark the conditions column as modified so SQLAlchemy knows it has changed
-                        # When you directly modify an element in a JSON column (like appending to a list),
-                        # SQLAlchemy may not automatically recognize it. Explicitly marking the attribute as
-                        # modified solves this issue.
-                        flag_modified(component_to_update, "conditions")
+                        # check is there similar condition is added into a component and if yes then it will be ignored,
+                        # this search will be done based on the unique name
+                        if any(d["name"] == new_condition.name for d in component_to_update.conditions) is False:
+                            component_to_update.conditions.append(asdict(new_condition))
+                            # Mark the conditions column as modified so SQLAlchemy knows it has changed
+                            # When you directly modify an element in a JSON column (like appending to a list),
+                            # SQLAlchemy may not automatically recognize it. Explicitly marking the attribute as
+                            # modified solves this issue.
+                            flag_modified(component_to_update, "conditions")
                     else:
                         component_to_update.conditions = [asdict(new_condition)]
 

--- a/tests/test_form_import.py
+++ b/tests/test_form_import.py
@@ -22,12 +22,12 @@ from tests.unit_test_data import test_form_json_condition_org_type_c
     "input_condition,exp_result",
     [
         (
-            test_form_json_condition_org_type_a,
-            test_condition_org_type_a,
+                test_form_json_condition_org_type_a,
+                test_condition_org_type_a,
         ),
         (
-            test_form_json_condition_org_type_c,
-            test_condition_org_type_c,
+                test_form_json_condition_org_type_c,
+                test_condition_org_type_c,
         ),
     ],
 )
@@ -96,6 +96,51 @@ def test_add_conditions_to_components(mocker, input_page, input_conditions, exp_
             assert mock_component.conditions
             assert len(mock_component.conditions) == exp_condition_count
         assert mock_build_condition.call_count == len(input_conditions)
+
+
+@pytest.mark.parametrize(
+    "input_page, input_conditions, exp_condition_count",
+    [
+        (
+                [
+                    {"path": "/path-1", "next": [{"path": "next-a", "condition": "condition-a"}]},
+                    {"path": "/path-2", "next": [{"path": "next-a", "condition": "condition-a"}]},
+                    {"path": "/path-3", "next": [{"path": "next-a", "condition": "condition-a"}]}
+                ],
+                [
+                    asdict(
+                        Condition(
+                            name="condition-a",
+                            display_name="condition a",
+                            destination_page_path="page-b",
+                            value=ConditionValue(
+                                name="condition a",
+                                conditions=[
+                                    SubCondition(field={"name": "c1"}, operator="is", value={}, coordinator=None),
+                                    SubCondition(field={"name": "c1"}, operator="is", value={}, coordinator="or"),
+                                ],
+                            ),
+                        )
+                    )
+                ],
+                1,
+        ),
+    ],
+)
+def test_same_condition_used_in_different_pages(mocker, input_page, input_conditions, exp_condition_count):
+    mock_component = Component()
+    mocker.patch("app.import_config.load_form_json._get_component_by_runner_name", return_value=mock_component)
+    mocker.patch("app.import_config.load_form_json.get_all_pages_in_parent_form", return_value=[uuid4()])
+
+    # Set up other necessary mocks and test data
+    with mock.patch(
+            "app.import_config.load_form_json._build_condition",
+            return_value=Condition(name=None, display_name=None, destination_page_path=None, value=None),
+    ):
+        for page in input_page:
+            add_conditions_to_components(None, page, input_conditions, page_id=None)
+        assert mock_component.conditions
+        assert len(mock_component.conditions) == exp_condition_count
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Ticket: https://mhclgdigital.atlassian.net/browse/FS-4882**

### Change description

**Issue Summary**

In a given form, we have multiple pages, and on a given page, we have components, and some of those components can have a list attached, and in a given list we can have various items. Based on these items, we can create multiple conditions and conditions will be attached into only one component. According to the following example you can see in the field section `Which datasets have you collected?` question field is used several times because we have conditions for each list item. 

```
"conditions": [
    {
      "displayName": "conservation areas",
      "name": "CNtvCT",
      "value": {
        "name": "conservation areas",
        "conditions": [
          {
            "field": {
              "name": "FjGMRE.PfjXKB",
              "type": "CheckboxesField",
              "display": "Which datasets have you collected?"
            },
            "operator": "contains",
            "value": {
              "type": "Value",
              "value": "conservation-areas",
              "display": "Conservation areas"
            }
          }
        ]
      }
    },
    {
      "displayName": "article 4s",
      "name": "ZepbPF",
      "value": {
        "name": "article 4s",
        "conditions": [
          {
            "field": {
              "name": "FjGMRE.PfjXKB",
              "type": "CheckboxesField",
              "display": "Which datasets have you collected?"
            },
            "operator": "contains",
            "value": {
              "type": "Value",
              "value": "article-4-direction",
              "display": "Article 4 direction"
            }
          }
        ]
      }
    },
    {
      "displayName": "listed buildings",
      "name": "fIzaVE",
      "value": {
        "name": "listed buildings",
        "conditions": [
          {
            "field": {
              "name": "FjGMRE.PfjXKB",
              "type": "CheckboxesField",
              "display": "Which datasets have you collected?"
            },
            "operator": "contains",
            "value": {
              "type": "Value",
              "value": "listed-buildings",
              "display": "Listed buildings"
            }
          }
        ]
      }
    },
    {
      "displayName": "tree preservation areas",
      "name": "nSTABU",
      "value": {
        "name": "tree preservation areas",
        "conditions": [
          {
            "field": {
              "name": "FjGMRE.PfjXKB",
              "type": "CheckboxesField",
              "display": "Which datasets have you collected?"
            },
            "operator": "contains",
            "value": {
              "type": "Value",
              "value": "tree-preservation-orders",
              "display": "Tree preservation orders"
            }
          }
        ]
      }
    }
  ]
``` 
In a given page after  `PfjXKB` this components page, you can use the above conditions multiple times as per your need, So given conditions can be referenced in the next part of the page when you want to change page direction based on conditions like the following example.

Ex.

```
Page: Which format is your dataset in for conservation areas?

"next": [
        {
          "path": "/which-format-is-your-dataset-in-for-article-4-direction",
          "condition": "ZepbPF"
        }
      ]

Page: Which datasets have you collected?

"next": [
        {
          "path": "/which-format-is-your-dataset-in-for-article-4-direction",
          "condition": "ZepbPF"
        }
      ]

``` 

So, in the FAB environment, we keep this condition under the component, and according to the above scenario, without this change under the component, there will be "2" conditions where created, then once we tried to preview the forms from runner complained that under conditions you have duplicate conditions created with the same configurations.

**Suggested solution** 

Before adding a condition to the component structure, check if is there any condition with the same name, if not just add it and update the database.

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test in FAB

1. Use Fab
2. Go to template management
3. Upload Dataset Information JSON if it is there delete it 
4. Preview it then it should work

Designer link for the form : https://form-designer.dev.access-funding.test.levellingup.gov.uk/app/designer/ziiQu7fnY6 

