### PR TITLE
FS-4872: support time field name change

### DIFF
--- a/app/blueprints/fund_builder/forms/round.py
+++ b/app/blueprints/fund_builder/forms/round.py
@@ -146,7 +146,7 @@ class RoundForm(FlaskForm):
     contact_email = StringField("Contact Email")
     contact_phone = StringField("Contact Phone")
     contact_textphone = StringField("Contact Textphone")
-    support_times = StringField("Support times", validators=[DataRequired()])
+    support_times = StringField("Support Times for Applicants", validators=[DataRequired()])
     support_days = StringField("Support Days", validators=[DataRequired()])
     instructions_en = TextAreaField("Instructions (English)")
     instructions_cy = StringField("Instructions (Welsh)", description="Leave blank for English-only funds")


### PR DESCRIPTION
**Ticket: https://mhclgdigital.atlassian.net/browse/FS-4872**


### Change description
As per the request  `Support times`  field will change into -> 'Support Times for Applicants'

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### Screenshots of UI changes (if applicable)
![image](https://github.com/user-attachments/assets/ac35c58b-d445-4bf5-a037-c50dab259ba9)
