### PR TITLE
FS-4848: Error banner handling in fund create/edit page, round add/edit page, template management page

### DIFF
--- a/app/blueprints/fund_builder/routes.py
+++ b/app/blueprints/fund_builder/routes.py
@@ -55,6 +55,7 @@ from app.export_config.generate_fund_round_form_jsons import (
     generate_form_jsons_for_round,
 )
 from app.export_config.generate_fund_round_html import generate_all_round_html
+from app.shared.helpers import error_formatter
 from config import Config
 
 BUILD_FUND_BP_INDEX = "build_fund_bp.index"
@@ -273,7 +274,8 @@ def fund(fund_id=None):
         flash(f"Created fund {form.name_en.data}")
         return redirect(url_for(BUILD_FUND_BP_INDEX))
 
-    return render_template("fund.html", form=form, fund_id=fund_id)
+    error = error_formatter(form.errors)
+    return render_template("fund.html", form=form, fund_id=fund_id, error=error)
 
 
 @build_fund_bp.route("/round", methods=["GET", "POST"])
@@ -303,8 +305,8 @@ def round(round_id=None):
     params["round_id"] = round_id
     params["form"] = form
 
-    return render_template("round.html", **params)
-
+    error = error_formatter(params["form"].errors)
+    return render_template("round.html", **params, error=error)
 
 def _convert_json_data_for_form(data) -> str:
     if isinstance(data, dict):

--- a/app/blueprints/fund_builder/templates/fund.html
+++ b/app/blueprints/fund_builder/templates/fund.html
@@ -5,9 +5,18 @@
 {% from "macros/wtfToGovUk.html" import yes_no %}
 {% from "macros/wtfToGovUk.html" import radios_from_enum %}
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
+{%- from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary -%}
 {% block content %}
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
+        {% if error %}
+            {{
+            govukErrorSummary({
+                "titleText": error.titleText,
+                "errorList": error.errorList
+            })
+            }}
+        {% endif %}
         <h1 class="govuk-heading-l">{{pageHeading}}</h1>
         <div class="govuk-form-group">
             <fieldset class="govuk-fieldset">

--- a/app/blueprints/fund_builder/templates/round.html
+++ b/app/blueprints/fund_builder/templates/round.html
@@ -7,9 +7,18 @@
 {% from "macros/wtfToGovUk.html" import yes_no %}
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 {%- from "govuk_frontend_jinja/components/select/macro.html" import govukSelect -%}
+{%- from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary -%}
 {% block content %}
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
+        {% if error %}
+            {{
+            govukErrorSummary({
+                "titleText": error.titleText,
+                "errorList": error.errorList
+            })
+            }}
+        {% endif %}
         <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
         <div class="govuk-form-group">
             <fieldset class="govuk-fieldset">

--- a/app/blueprints/templates/routes.py
+++ b/app/blueprints/templates/routes.py
@@ -16,6 +16,7 @@ from app.db.queries.application import get_all_template_sections
 from app.db.queries.application import get_form_by_id
 from app.db.queries.application import get_form_by_template_name
 from app.db.queries.application import update_form
+from app.shared.helpers import error_formatter
 
 # Blueprint for routes used by FAB PoC to manage templates
 template_bp = Blueprint(
@@ -88,7 +89,10 @@ def view_templates():
 
         return redirect(url_for("template_bp.view_templates"))
 
-    return render_template("view_templates.html", **params)
+    error = None
+    if 'uploadform' in params:
+        error = error_formatter(params['uploadform'].errors)
+    return render_template("view_templates.html", **params, error=error)
 
 
 @template_bp.route("/forms/<form_id>", methods=["GET", "POST"])
@@ -114,7 +118,10 @@ def edit_form_template(form_id):
             )
             return redirect(url_for("template_bp.view_templates"))
         params["template_form"] = template_form
-        return render_template("edit_form_template.html", **params)
+        error = None
+        if 'template_form' in params:
+            error = error_formatter(params['template_form'].errors)
+        return render_template("edit_form_template.html", **params, error=error)
 
     if request.args.get("action") == "remove":
         delete_form(form_id=form_id, cascade=True)

--- a/app/blueprints/templates/templates/edit_form_template.html
+++ b/app/blueprints/templates/templates/edit_form_template.html
@@ -2,6 +2,7 @@
 {%- from "govuk_frontend_jinja/components/file-upload/macro.html" import govukFileUpload -%}
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 {% from "govuk_frontend_jinja/components/table/macro.html" import govukTable %}
+{%- from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary -%}
 
 {% extends "base.html" %}
 {% set pageHeading %}
@@ -9,6 +10,14 @@ Rename Template
 {% endset %}
 {% block content %}
 <div class="govuk-grid-row">
+    {% if error %}
+        {{
+        govukErrorSummary({
+            "titleText": error.titleText,
+            "errorList": error.errorList
+        })
+        }}
+    {% endif %}
     <h1 class="govuk-heading-l">{{pageHeading}}</h1>
 </div>
 <div class="govuk-grid-row">

--- a/app/blueprints/templates/templates/view_templates.html
+++ b/app/blueprints/templates/templates/view_templates.html
@@ -2,6 +2,7 @@
 {%- from "govuk_frontend_jinja/components/file-upload/macro.html" import govukFileUpload -%}
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 {% from "govuk_frontend_jinja/components/table/macro.html" import govukTable %}
+{%- from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary -%}
 
 {% extends "base.html" %}
 {% set pageHeading %}
@@ -9,6 +10,14 @@
 {% endset %}
 {% block content %}
     <div class="govuk-grid-row">
+        {% if error %}
+            {{
+                govukErrorSummary({
+                    "titleText": error.titleText,
+                    "errorList": error.errorList
+                })
+            }}
+        {% endif %}
         <h1 class="govuk-heading-l">{{pageHeading}}</h1>
     </div>
     <div class="govuk-grid-row">

--- a/app/shared/helpers.py
+++ b/app/shared/helpers.py
@@ -36,3 +36,19 @@ def get_all_pages_in_parent_form(db, page_id):
     page_ids = [p.page_id for p in page_ids]
 
     return page_ids
+
+# This formatter will read all the errors and then convert them to the required format to support error-summary display
+def error_formatter(errors):
+    error = None
+    if errors:
+        errorsList = []
+        for field, errors in errors.items():
+            if isinstance(errors, list):
+                errorsList.extend([{'text': err, 'href': f'#{field}'} for err in errors])
+            elif isinstance(errors, dict):
+                # Check if any of the datetime fields have errors
+                if any(len(errors.get(key, '')) > 0 for key in ['day', 'month', 'years', 'hour', 'minute']):
+                    errorsList.append({'text': "Enter valid datetime", 'href': f'#{field}'})
+        if errorsList:
+            error = {'titleText': "There is a problem", 'errorList': errorsList}
+    return error


### PR DESCRIPTION
**Ticket: https://mhclgdigital.atlassian.net/browse/FS-4848**

### Change description
With this PR we are trying to add error banner for the following page 

1. Round create/update error banner handling
2. Fund create/update banner handling
3. Template management error handling 

- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### Screenshots of UI changes (if applicable)
![image](https://github.com/user-attachments/assets/c1a136c0-a7c7-4c58-98ad-7b14a95ed394)

![image](https://github.com/user-attachments/assets/47ab42f8-e326-42c5-94bd-6d3687c536b8)

![image](https://github.com/user-attachments/assets/7c4178f6-3c46-44c8-b5bc-9fa242b150c4)

![image](https://github.com/user-attachments/assets/67078a06-e338-413d-b9a8-6a3357997112)
