### PR TITLE
FS-4865: validating empty spaces between short names of the fund and round and also updating intelij idea setting

### DIFF
--- a/.idea/runConfigurations/FAB.xml
+++ b/.idea/runConfigurations/FAB.xml
@@ -5,11 +5,11 @@
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
-      <env name="DATABASE_URL" value="postgresql://postgres:password@localhost:5432/fsd_application_builder" />
+      <env name="DATABASE_URL" value="postgresql://postgres:password@localhost:5432/fab_store" />
       <env name="FLASK_DEBUG" value="0" />
       <env name="FLASK_ENV" value="development" />
-      <env name="FORM_RUNNER_EXTERNAL_HOST" value="http://localhost:3019" />
-      <env name="FORM_RUNNER_INTERNAL_HOST" value="=http://localhost:3009" />
+      <env name="FORM_RUNNER_EXTERNAL_HOST" value="http://localhost:3009" />
+      <env name="FORM_RUNNER_INTERNAL_HOST" value="http://localhost:3009" />
       <env name="PYTHONUNBUFFERED" value="1" />
       <env name="SECRET_KEY" value="local" />
     </envs>

--- a/app/blueprints/fund_builder/forms/fund.py
+++ b/app/blueprints/fund_builder/forms/fund.py
@@ -9,6 +9,7 @@ from wtforms.validators import DataRequired
 from wtforms.validators import Length
 
 from app.db.models.fund import FundingType
+from app.shared.helpers import no_spaces_between_letters
 
 
 class GovUkRadioEnumField(RadioField):
@@ -36,7 +37,7 @@ class FundForm(FlaskForm):
     name_cy = StringField("Name (Welsh)", description="Leave blank for English-only funds")
     title_en = StringField("Title (English)", validators=[DataRequired()])
     title_cy = StringField("Title (Welsh)", description="Leave blank for English-only funds")
-    short_name = StringField("Short Name", validators=[DataRequired(), Length(max=10)])
+    short_name = StringField("Short Name", validators=[DataRequired(), Length(max=10), no_spaces_between_letters])
     description_en = TextAreaField("Description", validators=[DataRequired()])
     description_cy = TextAreaField("Description (Welsh)", description="Leave blank for English-only funds")
     welsh_available = RadioField("Welsh Available", choices=[("true", "Yes"), ("false", "No")], default="false")

--- a/app/blueprints/fund_builder/forms/round.py
+++ b/app/blueprints/fund_builder/forms/round.py
@@ -14,6 +14,8 @@ from wtforms.validators import DataRequired
 from wtforms.validators import Length
 from wtforms.validators import ValidationError
 
+from app.shared.helpers import no_spaces_between_letters
+
 
 def validate_json_field(form, field):
     str_content = field.data
@@ -126,7 +128,7 @@ class RoundForm(FlaskForm):
     short_name = StringField(
         "Short Name",
         description="Choose a unique short name with 6 or fewer characters",
-        validators=[DataRequired(), Length(max=6)],
+        validators=[DataRequired(), Length(max=6), no_spaces_between_letters],
     )
     opens = FormField(DateInputForm, label="Opens")
     deadline = FormField(DateInputForm, label="Deadline")

--- a/app/shared/helpers.py
+++ b/app/shared/helpers.py
@@ -1,5 +1,7 @@
+import re
 from dataclasses import asdict
 from dataclasses import is_dataclass
+from wtforms.validators import ValidationError
 
 from app.db.models import Page
 
@@ -52,3 +54,12 @@ def error_formatter(errors):
         if errorsList:
             error = {'titleText': "There is a problem", 'errorList': errorsList}
     return error
+
+
+# Custom validator to check for spaces between letters
+def no_spaces_between_letters(form, field):
+    # Regular expression to check for spaces between letters
+    if not field.data:
+        return
+    if re.search(r'\b\w+\s+\w+\b', field.data):  # Matches sequences with spaces in between
+        raise ValidationError("Spaces between letters are not allowed.")


### PR DESCRIPTION
**Ticket: https://mhclgdigital.atlassian.net/browse/FS-4865**


### Change description
In this ticket we are adding extra validation to check does any users try to put empty spaces between the short name while in fund creation/update and round creation/update

- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

### Screenshots of UI changes (if applicable)

![image](https://github.com/user-attachments/assets/3b591a20-8026-4fe1-bab0-4b02b0504c8f)

![image](https://github.com/user-attachments/assets/ce4085ce-52e2-490c-92f7-bba156e5abb3)

