### PR TITLE
FS-4893 - Don't prepend 'Apply for' to exported summary page title

### DIFF
--- a/app/export_config/generate_form.py
+++ b/app/export_config/generate_form.py
@@ -284,7 +284,7 @@ def build_form_json(form: Form, fund_title: str = None) -> dict:
     """
 
     results = copy.deepcopy(BASIC_FORM_STRUCTURE)
-    results["name"] = f"Apply for {fund_title}" if fund_title else "Access Funding"
+    results["name"] = fund_title or "Access Funding"
     results["sections"] = []
     # Build the basic page structure
     for page in form.pages:

--- a/tests/test_config_export.py
+++ b/tests/test_config_export.py
@@ -202,7 +202,7 @@ def test_generate_form_jsons_for_round_valid_input(seed_dynamic_data, temp_outpu
                                 "options": {},
                                 "type": "Html",
                                 "content": '<p class="govuk-body"></p><p class="govuk-body">'
-                                           "We will ask you about:</p> <ul><li>Organisation Name</li></ul>",
+                                "We will ask you about:</p> <ul><li>Organisation Name</li></ul>",
                                 "schema": {},
                             }
                         ],
@@ -233,7 +233,7 @@ def test_generate_form_jsons_for_round_valid_input(seed_dynamic_data, temp_outpu
                 "sections": [],
                 "outputs": [],
                 "skipSummary": False,
-                "name": "Apply for funding to improve testing",
+                "name": "funding to improve testing",
             },
         }
     ]
@@ -268,12 +268,12 @@ def test_generate_fund_round_html(seed_dynamic_data, temp_output_dir):
     expected_files = [
         {
             "path": temp_output_dir
-                    / round_short_name
-                    / "html"
-                    / f"{fund_short_name.casefold()}_{round_short_name.casefold()}_all_questions_en.html",
+            / round_short_name
+            / "html"
+            / f"{fund_short_name.casefold()}_{round_short_name.casefold()}_all_questions_en.html",
             "expected_output": frontend_html_prefix
-                               + '<div class="govuk-!-margin-bottom-8">\n  <h2 class="govuk-heading-m ">\n    Table of contents\n  </h2>\n  <ol class="govuk-list govuk-list--number">\n    <li>\n      <a class="govuk-link" href="#organisation-information">\n        Organisation Information\n      </a>\n    </li>\n  </ol>\n  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" />\n  <h2 class="govuk-heading-l" id="organisation-information">\n    1. Organisation Information\n  </h2>\n  <h3 class="govuk-heading-m">\n    1.1. About your organisation\n  </h3>\n  <h4 class="govuk-heading-s">\n    1.1.1. Organisation Name\n  </h4>\n  <div class="govuk-body all-questions-component">\n    <p class="govuk-body">\n      What is your organisation\'s name?\n    </p>\n    <p class="govuk-body">\n      This must match the registered legal organisation name\n    </p>\n  </div>\n  <div class="govuk-body all-questions-component">\n    <p class="govuk-body">\n      How is your organisation classified?\n    </p>\n    <ul class="govuk-list govuk-list--bullet">\n      <li class="">\n        Charity\n      </li>\n      <li class="">\n        Public Limited Company\n      </li>\n    </ul>\n  </div>\n</div>'  # noqa: E501
-                               + frontend_html_suffix,
+            + '<div class="govuk-!-margin-bottom-8">\n  <h2 class="govuk-heading-m ">\n    Table of contents\n  </h2>\n  <ol class="govuk-list govuk-list--number">\n    <li>\n      <a class="govuk-link" href="#organisation-information">\n        Organisation Information\n      </a>\n    </li>\n  </ol>\n  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" />\n  <h2 class="govuk-heading-l" id="organisation-information">\n    1. Organisation Information\n  </h2>\n  <h3 class="govuk-heading-m">\n    1.1. About your organisation\n  </h3>\n  <h4 class="govuk-heading-s">\n    1.1.1. Organisation Name\n  </h4>\n  <div class="govuk-body all-questions-component">\n    <p class="govuk-body">\n      What is your organisation\'s name?\n    </p>\n    <p class="govuk-body">\n      This must match the registered legal organisation name\n    </p>\n  </div>\n  <div class="govuk-body all-questions-component">\n    <p class="govuk-body">\n      How is your organisation classified?\n    </p>\n    <ul class="govuk-list govuk-list--bullet">\n      <li class="">\n        Charity\n      </li>\n      <li class="">\n        Public Limited Company\n      </li>\n    </ul>\n  </div>\n</div>'  # noqa: E501
+            + frontend_html_suffix,
         }
     ]
     for expected_file in expected_files:
@@ -325,9 +325,10 @@ def test_invalid_data_validate_json(data):
 
 def test_create_export_zip(temp_output_dir):
     test_data_path = Path("tests") / "test_data"
-    random_post_fix = ''.join(secrets.choice(string.ascii_uppercase + string.digits) for _ in range(5))
-    output = create_export_zip(directory_to_zip=test_data_path, zip_file_name="test_zip",
-                               random_post_fix=random_post_fix)
+    random_post_fix = "".join(secrets.choice(string.ascii_uppercase + string.digits) for _ in range(5))
+    output = create_export_zip(
+        directory_to_zip=test_data_path, zip_file_name="test_zip", random_post_fix=random_post_fix
+    )
     assert output
     output_path = Path(output)
     assert output_path.exists()


### PR DESCRIPTION
### Ticket

[Summary Page Title](https://mhclgdigital.atlassian.net/browse/FS-4893)

### Description

Currently we prepend "Apply for" to the fund title as part of the FAB export. This causes weird wording on application summary page (Apply frontend) e.g., "Application for Apply for..."

### Testing instructions

_To follow..._