### PR TITLE
FS-4899 - Create new list for each form even where list name (ID) is the same

### DIFF
--- a/app/db/queries/application.py
+++ b/app/db/queries/application.py
@@ -53,11 +53,6 @@ def get_list_by_id(list_id: str) -> Lizt:
     return lizt
 
 
-def get_list_by_name(list_name: str) -> Lizt:
-    lizt = db.session.query(Lizt).filter_by(name=list_name).first()
-    return lizt
-
-
 def _initiate_cloned_component(to_clone: Component, new_page_id=None, new_theme_id=None):
     clone = Component(**to_clone.as_dict())
 

--- a/tests/test_form_import.py
+++ b/tests/test_form_import.py
@@ -5,9 +5,7 @@ from uuid import uuid4
 import pytest
 
 from app.db.models.application_config import Component
-from app.db.models.application_config import Lizt
 from app.import_config.load_form_json import _build_condition
-from app.import_config.load_form_json import _find_list_and_create_if_not_existing
 from app.import_config.load_form_json import add_conditions_to_components
 from app.shared.data_classes import Condition
 from app.shared.data_classes import ConditionValue
@@ -22,12 +20,12 @@ from tests.unit_test_data import test_form_json_condition_org_type_c
     "input_condition,exp_result",
     [
         (
-                test_form_json_condition_org_type_a,
-                test_condition_org_type_a,
+            test_form_json_condition_org_type_a,
+            test_condition_org_type_a,
         ),
         (
-                test_form_json_condition_org_type_c,
-                test_condition_org_type_c,
+            test_form_json_condition_org_type_c,
+            test_condition_org_type_c,
         ),
     ],
 )
@@ -102,28 +100,28 @@ def test_add_conditions_to_components(mocker, input_page, input_conditions, exp_
     "input_page, input_conditions, exp_condition_count",
     [
         (
-                [
-                    {"path": "/path-1", "next": [{"path": "next-a", "condition": "condition-a"}]},
-                    {"path": "/path-2", "next": [{"path": "next-a", "condition": "condition-a"}]},
-                    {"path": "/path-3", "next": [{"path": "next-a", "condition": "condition-a"}]}
-                ],
-                [
-                    asdict(
-                        Condition(
-                            name="condition-a",
-                            display_name="condition a",
-                            destination_page_path="page-b",
-                            value=ConditionValue(
-                                name="condition a",
-                                conditions=[
-                                    SubCondition(field={"name": "c1"}, operator="is", value={}, coordinator=None),
-                                    SubCondition(field={"name": "c1"}, operator="is", value={}, coordinator="or"),
-                                ],
-                            ),
-                        )
+            [
+                {"path": "/path-1", "next": [{"path": "next-a", "condition": "condition-a"}]},
+                {"path": "/path-2", "next": [{"path": "next-a", "condition": "condition-a"}]},
+                {"path": "/path-3", "next": [{"path": "next-a", "condition": "condition-a"}]},
+            ],
+            [
+                asdict(
+                    Condition(
+                        name="condition-a",
+                        display_name="condition a",
+                        destination_page_path="page-b",
+                        value=ConditionValue(
+                            name="condition a",
+                            conditions=[
+                                SubCondition(field={"name": "c1"}, operator="is", value={}, coordinator=None),
+                                SubCondition(field={"name": "c1"}, operator="is", value={}, coordinator="or"),
+                            ],
+                        ),
                     )
-                ],
-                1,
+                )
+            ],
+            1,
         ),
     ],
 )
@@ -134,47 +132,10 @@ def test_same_condition_used_in_different_pages(mocker, input_page, input_condit
 
     # Set up other necessary mocks and test data
     with mock.patch(
-            "app.import_config.load_form_json._build_condition",
-            return_value=Condition(name=None, display_name=None, destination_page_path=None, value=None),
+        "app.import_config.load_form_json._build_condition",
+        return_value=Condition(name=None, display_name=None, destination_page_path=None, value=None),
     ):
         for page in input_page:
             add_conditions_to_components(None, page, input_conditions, page_id=None)
         assert mock_component.conditions
         assert len(mock_component.conditions) == exp_condition_count
-
-
-@pytest.mark.parametrize(
-    "input_list_name,input_all_lists, existing_list",
-    [
-        ("existing-list", [{"name": "existing-list"}], Lizt(list_id=uuid4())),
-    ],
-)
-def test_find_list_and_create_existing(mocker, input_list_name, input_all_lists, existing_list):
-    with (
-        mock.patch(
-            "app.import_config.load_form_json.get_list_by_name", return_value=existing_list
-        ) as get_list_by_name_mock,
-        mock.patch(
-            "app.import_config.load_form_json.insert_list", return_value=Lizt(list_id="new-list-id")
-        ) as insert_list_mock,
-    ):
-        result = _find_list_and_create_if_not_existing(list_name=input_list_name, all_lists_in_form=input_all_lists)
-        assert result == existing_list.list_id
-        assert get_list_by_name_mock.called_once_with(list_name=input_list_name)
-        insert_list_mock.assert_not_called()
-
-
-@pytest.mark.parametrize("input_list_name,input_all_lists, existing_list", [("new-list", [{"name": "new-list"}], None)])
-def test_find_list_and_create_not_existing(mocker, input_list_name, input_all_lists, existing_list):
-    with (
-        mock.patch(
-            "app.import_config.load_form_json.get_list_by_name", return_value=existing_list
-        ) as get_list_by_name_mock,
-        mock.patch(
-            "app.import_config.load_form_json.insert_list", return_value=Lizt(list_id="new-list-id")
-        ) as insert_list_mock,
-    ):
-        result = _find_list_and_create_if_not_existing(list_name=input_list_name, all_lists_in_form=input_all_lists)
-        assert result == "new-list-id"
-        assert get_list_by_name_mock.called_once_with(list_name=input_list_name)
-        insert_list_mock.called_once()


### PR DESCRIPTION
### Ticket

[Create new list for every form even where names collide](https://mhclgdigital.atlassian.net/browse/FS-4899)

### Description

Lists are scoped to forms. If two list-containing forms are loaded into FAB, even if those lists have the same name identifier, we should create two distinct lists in FAB, to preserve the data in those lists.

Currently, we do not do this. We check whether a list with the same name exists in the database, and if so we do not add the list.

This wouldn't be a practical problem if users created forms in isolation, as random identifiers are used for list names and these are unlikely to collide. The problem is that users clone forms, thereby cloning these random identifiers.