### PR TITLE
FS-4861 - Show or hide Welsh-specific fields depending on Welsh available toggle

### DIFF
--- a/app/blueprints/fund_builder/forms/fund.py
+++ b/app/blueprints/fund_builder/forms/fund.py
@@ -47,7 +47,7 @@ class FundForm(FlaskForm):
     title_cy = StringField("Title (Welsh)")
     short_name = StringField("Short name", validators=[DataRequired(), Length(max=10), no_spaces_between_letters,
                                                        validate_unique_fund_short_name])
-    description_en = TextAreaField("Description", validators=[DataRequired()])
+    description_en = TextAreaField("Description (English)", validators=[DataRequired()])
     description_cy = TextAreaField("Description (Welsh)")
     welsh_available = RadioField("Welsh available", choices=[("true", "Yes"), ("false", "No")], default="false")
     funding_type = GovUkRadioEnumField(label="Funding type", source_enum=FundingType)

--- a/app/blueprints/fund_builder/forms/fund.py
+++ b/app/blueprints/fund_builder/forms/fund.py
@@ -42,13 +42,13 @@ class GovUkRadioEnumField(RadioField):
 class FundForm(FlaskForm):
     fund_id = HiddenField("Fund ID")
     name_en = StringField("Name (English)", validators=[DataRequired()])
-    name_cy = StringField("Name (Welsh)", description="Leave blank for English-only funds")
+    name_cy = StringField("Name (Welsh)")
     title_en = StringField("Title (English)", validators=[DataRequired()])
-    title_cy = StringField("Title (Welsh)", description="Leave blank for English-only funds")
+    title_cy = StringField("Title (Welsh)")
     short_name = StringField("Short name", validators=[DataRequired(), Length(max=10), no_spaces_between_letters,
                                                        validate_unique_fund_short_name])
     description_en = TextAreaField("Description", validators=[DataRequired()])
-    description_cy = TextAreaField("Description (Welsh)", description="Leave blank for English-only funds")
+    description_cy = TextAreaField("Description (Welsh)")
     welsh_available = RadioField("Welsh available", choices=[("true", "Yes"), ("false", "No")], default="false")
     funding_type = GovUkRadioEnumField(label="Funding type", source_enum=FundingType)
     ggis_scheme_reference_number = StringField("GGIS scheme reference number", validators=[Length(max=255)])

--- a/app/blueprints/fund_builder/forms/round.py
+++ b/app/blueprints/fund_builder/forms/round.py
@@ -134,7 +134,7 @@ class RoundForm(FlaskForm):
     round_id = HiddenField("Round ID")
     fund_id = StringField("Fund", validators=[DataRequired()])
     title_en = StringField("Title (English)", validators=[DataRequired()])
-    title_cy = StringField("Title (Welsh)", description="Leave blank for English-only funds")
+    title_cy = StringField("Title (Welsh)")
     short_name = StringField(
         "Short name",
         description="Choose a unique short name with 6 or fewer characters",

--- a/app/blueprints/fund_builder/forms/round.py
+++ b/app/blueprints/fund_builder/forms/round.py
@@ -151,7 +151,7 @@ class RoundForm(FlaskForm):
     contact_us_banner_en = TextAreaField(
         "Contact Us banner (English)", description="HTML to display to override the default 'Contact Us' page content"
     )
-    contact_us_banner_cy = TextAreaField("Contact Us banner (Welsh)", description="Leave blank for English-only funds")
+    contact_us_banner_cy = TextAreaField("Contact Us banner (Welsh)")
     reference_contact_page_over_email = RadioField(
         "Reference contact page over email", choices=[("true", "Yes"), ("false", "No")], default="false"
     )
@@ -161,13 +161,11 @@ class RoundForm(FlaskForm):
     support_times = StringField("Support times for applicants", validators=[DataRequired()])
     support_days = StringField("Support days", validators=[DataRequired()])
     instructions_en = TextAreaField("Instructions (English)")
-    instructions_cy = StringField("Instructions (Welsh)", description="Leave blank for English-only funds")
+    instructions_cy = StringField("Instructions (Welsh)")
     feedback_link = URLField("Feedback link", validators=[validate_flexible_url])
     project_name_field_id = StringField("Project name field ID", validators=[DataRequired()])
     application_guidance_en = TextAreaField("Application guidance (English)")
-    application_guidance_cy = TextAreaField(
-        "Application guidance (Welsh)", description="Leave blank for English-only funds"
-    )
+    application_guidance_cy = TextAreaField("Application guidance (Welsh)")
     guidance_url = URLField("Guidance link", validators=[validate_flexible_url])
     all_uploaded_documents_section_available = RadioField(choices=[("true", "Yes"), ("false", "No")], default="false")
     application_fields_download_available = RadioField(

--- a/app/blueprints/fund_builder/routes.py
+++ b/app/blueprints/fund_builder/routes.py
@@ -301,8 +301,10 @@ def round(round_id=None):
     and saves to DB
     """
     form = RoundForm()
-    params = {"all_funds": all_funds_as_govuk_select_items(get_all_funds())}
+    all_funds = get_all_funds()
+    params = {"all_funds": all_funds_as_govuk_select_items(all_funds)}
     params["selected_fund_id"] = request.form.get("fund_id", None)
+    params["welsh_availability"] = json.dumps({str(fund.fund_id): fund.welsh_available for fund in all_funds})
 
     if round_id:
         round = get_round_by_id(round_id)

--- a/app/blueprints/fund_builder/templates/fund.html
+++ b/app/blueprints/fund_builder/templates/fund.html
@@ -21,17 +21,16 @@
         <div class="govuk-form-group">
             <fieldset class="govuk-fieldset">
                 <form method="POST">
-
                     {{ form.hidden_tag()}}
 
+                    {{yes_no(form.welsh_available)}}
                     {{input(form.name_en)}}
-                    {{input(form.name_cy)}}
+                    {{input(form.name_cy, classes="welsh-field")}}
                     {{input(form.title_en)}}
-                    {{input(form.title_cy)}}
+                    {{input(form.title_cy, classes="welsh-field")}}
                     {{input(form.short_name)}}
                     {{multilineinput(form.description_en)}}
-                    {{multilineinput(form.description_cy)}}
-                    {{yes_no(form.welsh_available)}}
+                    {{multilineinput(form.description_cy, classes="welsh-field")}}
                     {{radios_from_enum(form.funding_type)}}
                     {{input(form.ggis_scheme_reference_number)}}
                     <div class="govuk-!-margin-top-6">
@@ -44,4 +43,32 @@
         </div>
     </div>
 </div>
+
+<script>
+function toggleWelshFields() {
+    const welshAvailable = document.querySelector('input[name="welsh_available"]:checked').value;
+    const welshFields = document.querySelectorAll('.welsh-field');
+
+    welshFields.forEach(field => {
+        const fieldContainer = field.closest('.govuk-form-group');
+        if (welshAvailable === 'true') {
+            fieldContainer.style.display = 'block';
+        } else {
+            fieldContainer.style.display = 'none';
+            field.value = '';
+        }
+    });
+}
+
+// Run on page load
+document.addEventListener('DOMContentLoaded', function() {
+    toggleWelshFields();
+
+    // Add change event listeners to radio buttons
+    const radios = document.querySelectorAll('input[name="welsh_available"]');
+    radios.forEach(radio => {
+        radio.addEventListener('change', toggleWelshFields);
+    });
+});
+</script>
 {% endblock content %}

--- a/app/blueprints/fund_builder/templates/fund.html
+++ b/app/blueprints/fund_builder/templates/fund.html
@@ -55,7 +55,6 @@ function toggleWelshFields() {
             fieldContainer.style.display = 'block';
         } else {
             fieldContainer.style.display = 'none';
-            field.value = '';
         }
     });
 }

--- a/app/blueprints/fund_builder/templates/round.html
+++ b/app/blueprints/fund_builder/templates/round.html
@@ -98,7 +98,6 @@ function toggleWelshFields() {
             fieldContainer.style.display = 'block';
         } else {
             fieldContainer.style.display = 'none';
-            field.value = '';
         }
     });
 }

--- a/app/blueprints/fund_builder/templates/round.html
+++ b/app/blueprints/fund_builder/templates/round.html
@@ -12,12 +12,10 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         {% if error %}
-            {{
-            govukErrorSummary({
+            {{ govukErrorSummary({
                 "titleText": error.titleText,
                 "errorList": error.errorList
-            })
-            }}
+            }) }}
         {% endif %}
         <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
         <div class="govuk-form-group">
@@ -29,17 +27,17 @@
                             "id": form.fund_id.id,
                             "name": form.fund_id.name,
                             "label": {
-                            "text": form.fund_id.label
+                                "text": form.fund_id.label
                             },
                             "items": all_funds,
-                            "value":selected_fund_id,
+                            "value": selected_fund_id,
                             "errorMessage": {
                                 "text": form.fund_id.errors[0] if form.fund_id.errors else ""
                             } if form.fund_id.errors else None
                         })}}
                     {% endif %}
                     {{input(form.title_en)}}
-                    {{input(form.title_cy)}}
+                    {{input(form.title_cy, classes="welsh-field")}}
                     {{input(form.short_name)}}
                     {{dateinput(form.opens)}}
                     {{dateinput(form.deadline)}}
@@ -49,7 +47,7 @@
                     {{input(form.prospectus_link)}}
                     {{input(form.privacy_notice_link)}}
                     {{ multilineinput(form.contact_us_banner_en) }}
-                    {{ multilineinput(form.contact_us_banner_cy) }}
+                    {{ multilineinput(form.contact_us_banner_cy, classes="welsh-field") }}
                     {{ yes_no(form.reference_contact_page_over_email) }}
                     {{ input(form.contact_email) }}
                     {{ input(form.contact_phone) }}
@@ -57,11 +55,11 @@
                     {{ input(form.support_times) }}
                     {{ input(form.support_days) }}
                     {{ multilineinput(form.instructions_en) }}
-                    {{ multilineinput(form.instructions_cy) }}
+                    {{ multilineinput(form.instructions_cy, classes="welsh-field") }}
                     {{input(form.feedback_link)}}
                     {{ input(form.project_name_field_id) }}
                     {{ multilineinput(form.application_guidance_en) }}
-                    {{ multilineinput(form.application_guidance_cy) }}
+                    {{ multilineinput(form.application_guidance_cy, classes="welsh-field") }}
                     {{ input(form.guidance_url) }}
                     {{ yes_no(form.application_fields_download_available) }}
                     {{ yes_no(form.display_logo_on_pdf_exports) }}
@@ -75,13 +73,43 @@
                     {{ yes_no(form.is_research_survey_optional) }}
                     {{ yes_no(form.eligibility_config) }}
                     {{ multilineinput(form.eoi_decision_schema_en) }}
-                    {{ multilineinput(form.eoi_decision_schema_cy) }}
+                    {{ multilineinput(form.eoi_decision_schema_cy, classes="welsh-field") }}
                     {{ govukButton({
-                    "text": "Save"
+                        "text": "Save"
                     }) }}
                 </form>
             </fieldset>
         </div>
     </div>
 </div>
+
+<script>
+// Store Welsh availability mapping passed from the route handler
+const welshAvailability = {{ welsh_availability | safe }};
+
+function toggleWelshFields() {
+    const fundSelect = document.querySelector('#fund_id');
+    const isWelshAvailable = welshAvailability[fundSelect.value];
+    const welshFields = document.querySelectorAll('.welsh-field');
+
+    welshFields.forEach(field => {
+        const fieldContainer = field.closest('.govuk-form-group');
+        if (isWelshAvailable) {
+            fieldContainer.style.display = 'block';
+        } else {
+            fieldContainer.style.display = 'none';
+            field.value = '';
+        }
+    });
+}
+
+// Run on page load
+document.addEventListener('DOMContentLoaded', function() {
+    toggleWelshFields();
+
+    // Add change event listener to fund select
+    const fundSelect = document.querySelector('#fund_id');
+    fundSelect.addEventListener('change', toggleWelshFields);
+});
+</script>
 {% endblock content %}

--- a/app/templates/macros/wtfToGovUk.html
+++ b/app/templates/macros/wtfToGovUk.html
@@ -4,29 +4,31 @@
 {% from "govuk_frontend_jinja/components/textarea/macro.html" import govukTextarea %}
 {% from "govuk_frontend_jinja/components/date-input/macro.html" import govukDateInput %}
 
-{% macro input(form_field) %}
+{% macro input(form_field, classes="") %}
 {{ govukInput({
 "label": {
-"text": form_field.label ,
+"text": form_field.label,
 "isPageHeading": false
 },
 "id": form_field.id,
-"name": form_field.name ,
+"name": form_field.name,
 "value": form_field.data,
+"classes": classes,
 "errorMessage": {"text": form_field.errors[0]} if (form_field.errors | length > 0) else None,
 "hint":{"text":form_field.description}
 }) }}
 {%endmacro%}
 
-{% macro multilineinput(form_field) %}
+{% macro multilineinput(form_field, classes="") %}
 {{ govukTextarea({
 "label": {
-"text": form_field.label ,
+"text": form_field.label,
 "isPageHeading": false
 },
 "id": form_field.id,
-"name": form_field.name ,
+"name": form_field.name,
 "value": form_field.data if form_field.data else "",
+"classes": classes,
 "errorMessage": {"text": form_field.errors[0]} if (form_field.errors | length > 0) else None,
 "hint":{"text":form_field.description}
 }) }}


### PR DESCRIPTION
### Ticket

[Show or hide Welsh-specific fields depending on Welsh available toggle](https://mhclgdigital.atlassian.net/browse/FS-4861)

### Description

FAB users are asked on the “Create a Fund” page to specify whether Welsh is available for the fund. However, regardless of what they select, we show fields that are only relevant if the answer is yes (Welsh is available), e.g., “Description (Welsh)”. This clutters the interface unnecessarily.

To resolve this, we should only show Welsh-specific fields if Welsh is selected as available. We should do this for fields on both the “Create a Fund” and “Create a Round” pages. We should move the Welsh available toggle above all Welsh-specific fields so that the user flow makes sense.

### Testing instructions

Pre-requisites...
- For devs - checkout this branch, restart FAB Docker container locally
- For others - ensure this branch is deployed to the dev environment (go [here](https://github.com/communitiesuk/funding-service-design-fund-application-builder/actions/workflows/copilot_deploy.yml), click "Run workflow" in top right corner, select this branch for "Use workflow from", select "dev" for "Which AWS account to use", click "Run workflow", await job completion)

The below instructions are relevant for the dev environment. If you are testing locally, you will need to change the URLs.

**Test 1 - Welsh available toggle affects visibility of fields on "Create a Fund" page**

1. Go to the [Create a Fund](https://fund-application-builder.dev.access-funding.test.levellingup.gov.uk/fund) page
2. Toggle "Welsh available" from "No" to "Yes"
3. Observe the fields "Name (Welsh)", "Title (Welsh)" and "Description (Welsh)" materialising
4. Toggle "Welsh available" back to "No"
5. Observe those same fields disappearing

**Test 2 - Welsh available toggle deletes data from hidden fields**
1. Go to the [Create a Fund](https://fund-application-builder.dev.access-funding.test.levellingup.gov.uk/fund) page
2. Toggle "Welsh available" from "No" to "Yes"
3. Observe the fields "Name (Welsh)", "Title (Welsh)" and "Description (Welsh)" materialising
4. Enter some text in the field "Name (Welsh)"
5. Toggle "Welsh available" back to "No", and then back again to "Yes"
6. Observe that the text you entered in the field "Name (Welsh)" has disappeared

**Test 3 - Welsh available for a fund affects visibility of fields on "Create a Round" page**
1. Create a fund with Welsh available set to "Yes"
2. Create another fund with Welsh available set to "No"
3. Go to the [Create a Round](https://fund-application-builder.dev.access-funding.test.levellingup.gov.uk/round) page
4. Select the fund with Welsh available from the "Fund" dropdown at the top
5. Observe fields including "Title (Welsh)" - just below "Title (English)" - materialising
6. Select the fund with Welsh not available from the "Fund" dropdown
7. Observe those same fields disappearing