### PR TITLE
FS-4895: When creating a fund or a round check, whether given round shortnames are available

### DIFF
--- a/.idea/runConfigurations/FAB.xml
+++ b/.idea/runConfigurations/FAB.xml
@@ -5,12 +5,14 @@
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+      <env name="AUTHENTICATOR_HOST" value="https://authenticator.levellingup.gov.localhost:4004" />
       <env name="DATABASE_URL" value="postgresql://postgres:password@localhost:5432/fab_store" />
       <env name="FLASK_DEBUG" value="0" />
       <env name="FLASK_ENV" value="development" />
       <env name="FORM_RUNNER_EXTERNAL_HOST" value="http://localhost:3009" />
       <env name="FORM_RUNNER_INTERNAL_HOST" value="http://localhost:3009" />
-      <env name="PYTHONUNBUFFERED" value="1" />
+      <env name="RSA256_PUBLIC_KEY_BASE64" value="&quot;LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlHZU1BMEdDU3FHU0liM0RRRUJBUVVBQTRHTUFEQ0JpQUtCZ0hHYnRGMXlWR1crckNBRk9JZGFrVVZ3Q2Z1dgp4SEUzOGxFL2kwS1dwTXdkU0haRkZMWW5IakJWT09oMTVFaWl6WXphNEZUSlRNdkwyRTRRckxwcVlqNktFNnR2CkhyaHlQL041ZnlwU3p0OHZDajlzcFo4KzBrRnVjVzl6eU1rUHVEaXNZdG1rV0dkeEJta2QzZ3RZcDNtT0k1M1YKVkRnS2J0b0lGVTNzSWs1TkFnTUJBQUU9Ci0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQ==&quot;" />
       <env name="SECRET_KEY" value="local" />
     </envs>
     <option name="SDK_HOME" value="" />
@@ -21,7 +23,7 @@
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
     <option name="SCRIPT_NAME" value="flask" />
-    <option name="PARAMETERS" value="run --port 3020 --cert=$PROJECT_DIR$/../../../../fund_projects/funding-service-design-docker-runner/certs/cert.pem --key=$PROJECT_DIR$/../../../../fund_projects/funding-service-design-docker-runner/certs/key.pem" />
+    <option name="PARAMETERS" value="run --port 3011 --cert=$PROJECT_DIR$/../../certs/cert.pem --key=$PROJECT_DIR$/../../certs/key.pem" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
     <option name="MODULE_MODE" value="true" />

--- a/app/blueprints/fund_builder/routes.py
+++ b/app/blueprints/fund_builder/routes.py
@@ -40,11 +40,11 @@ from app.db.queries.application import move_form_up
 from app.db.queries.application import move_section_down
 from app.db.queries.application import move_section_up
 from app.db.queries.application import update_section
-from app.db.queries.fund import add_fund
+from app.db.queries.fund import add_fund, get_fund_by_short_name
 from app.db.queries.fund import get_all_funds
 from app.db.queries.fund import get_fund_by_id
 from app.db.queries.fund import update_fund
-from app.db.queries.round import add_round
+from app.db.queries.round import add_round, get_round_by_short_name_and_fund_id
 from app.db.queries.round import get_round_by_id
 from app.db.queries.round import update_round
 from app.export_config.generate_all_questions import print_html
@@ -254,42 +254,49 @@ def fund(fund_id=None):
     else:
         form = FundForm()
 
+    error = {}
     if form.validate_on_submit():
-        if fund_id:
-            fund.name_json["en"] = form.name_en.data
-            fund.name_json["cy"] = form.name_cy.data
-            fund.title_json["en"] = form.title_en.data
-            fund.title_json["cy"] = form.title_cy.data
-            fund.description_json["en"] = form.description_en.data
-            fund.description_json["cy"] = form.description_cy.data
-            fund.welsh_available = form.welsh_available.data == "true"
-            fund.short_name = form.short_name.data
-            fund.audit_info = {"user": "dummy_user", "timestamp": datetime.now().isoformat(), "action": "update"}
-            fund.funding_type = form.funding_type.data
-            fund.ggis_scheme_reference_number = (
-                form.ggis_scheme_reference_number.data if form.ggis_scheme_reference_number.data else ""
+        is_short_name_available = False
+        if form.data and form.data['short_name']:
+            fund_data = get_fund_by_short_name(form.data['short_name'])
+            is_short_name_available = fund_data and str(fund_data.fund_id) != fund_id
+        if not is_short_name_available:
+            if fund_id:
+                fund.name_json["en"] = form.name_en.data
+                fund.name_json["cy"] = form.name_cy.data
+                fund.title_json["en"] = form.title_en.data
+                fund.title_json["cy"] = form.title_cy.data
+                fund.description_json["en"] = form.description_en.data
+                fund.description_json["cy"] = form.description_cy.data
+                fund.welsh_available = form.welsh_available.data == "true"
+                fund.short_name = form.short_name.data
+                fund.audit_info = {"user": "dummy_user", "timestamp": datetime.now().isoformat(), "action": "update"}
+                fund.funding_type = form.funding_type.data
+                fund.ggis_scheme_reference_number = (
+                    form.ggis_scheme_reference_number.data if form.ggis_scheme_reference_number.data else ""
+                )
+                update_fund(fund)
+                flash(f"Updated fund {form.title_en.data}")
+                return redirect(url_for("build_fund_bp.view_fund", fund_id=fund.fund_id))
+
+            new_fund = Fund(
+                name_json={"en": form.name_en.data},
+                title_json={"en": form.title_en.data},
+                description_json={"en": form.description_en.data},
+                welsh_available=form.welsh_available.data == "true",
+                short_name=form.short_name.data,
+                audit_info={"user": "dummy_user", "timestamp": datetime.now().isoformat(), "action": "create"},
+                funding_type=FundingType(form.funding_type.data),
+                ggis_scheme_reference_number=(
+                    form.ggis_scheme_reference_number.data if form.ggis_scheme_reference_number.data else ""
+                ),
             )
-            update_fund(fund)
-            flash(f"Updated fund {form.title_en.data}")
-            return redirect(url_for("build_fund_bp.view_fund", fund_id=fund.fund_id))
-
-        new_fund = Fund(
-            name_json={"en": form.name_en.data},
-            title_json={"en": form.title_en.data},
-            description_json={"en": form.description_en.data},
-            welsh_available=form.welsh_available.data == "true",
-            short_name=form.short_name.data,
-            audit_info={"user": "dummy_user", "timestamp": datetime.now().isoformat(), "action": "create"},
-            funding_type=FundingType(form.funding_type.data),
-            ggis_scheme_reference_number=(
-                form.ggis_scheme_reference_number.data if form.ggis_scheme_reference_number.data else ""
-            ),
-        )
-        add_fund(new_fund)
-        flash(f"Created fund {form.name_en.data}")
-        return redirect(url_for(BUILD_FUND_BP_DASHBOARD))
-
-    error = error_formatter(form)
+            add_fund(new_fund)
+            flash(f"Created fund {form.name_en.data}")
+            return redirect(url_for(BUILD_FUND_BP_DASHBOARD))
+        error = {**error,
+                 'short_name': [f'Given fund short name already exists.']}
+    error = error_formatter(form.errors, error)
     return render_template("fund.html", form=form, fund_id=fund_id, error=error)
 
 
@@ -303,24 +310,30 @@ def round(round_id=None):
     form = RoundForm()
     params = {"all_funds": all_funds_as_govuk_select_items(get_all_funds())}
     params["selected_fund_id"] = request.form.get("fund_id", None)
-
+    error = {}
     if round_id:
         round = get_round_by_id(round_id)
         form = populate_form_with_round_data(round)
-
     if form.validate_on_submit():
-        if round_id:
-            update_existing_round(round, form)
-            flash(f"Updated round {round.title_json['en']}")
-            return redirect(url_for("build_fund_bp.view_fund", fund_id=round.fund_id))
-        create_new_round(form)
-        flash(f"Created round {form.title_en.data}")
-        return redirect(url_for(BUILD_FUND_BP_DASHBOARD))
-
+        is_short_name_available = False
+        if form.data and form.data['short_name'] and form.data['fund_id']:
+            rond_data = get_round_by_short_name_and_fund_id(form.data['fund_id'],
+                                                            form.data['short_name'])
+            is_short_name_available = rond_data and str(rond_data.round_id) != round_id
+        if not is_short_name_available:
+            if round_id:
+                update_existing_round(round, form)
+                flash(f"Updated round {round.title_json['en']}")
+                return redirect(url_for("build_fund_bp.view_fund", fund_id=round.fund_id))
+            create_new_round(form)
+            flash(f"Created round {form.title_en.data}")
+            return redirect(url_for(BUILD_FUND_BP_DASHBOARD))
+        fund = get_fund_by_id(form.data['fund_id'])
+        error = {**error,
+                 'short_name': [f'Given short name already exists in the fund {fund.title_json.get("en")}.']}
     params["round_id"] = round_id
     params["form"] = form
-
-    error = error_formatter(params["form"])
+    error = error_formatter(params["form"].errors, error)
     return render_template("round.html", **params, error=error)
 
 
@@ -399,19 +412,19 @@ def populate_form_with_round_data(round):
         "is_feedback_survey_optional": (
             "true"
             if round.feedback_survey_config
-            and round.feedback_survey_config.get("is_feedback_survey_optional", "") == "true"
+               and round.feedback_survey_config.get("is_feedback_survey_optional", "") == "true"
             else "false"
         ),
         "is_section_feedback_optional": (
             "true"
             if round.feedback_survey_config
-            and round.feedback_survey_config.get("is_section_feedback_optional", "") == "true"
+               and round.feedback_survey_config.get("is_section_feedback_optional", "") == "true"
             else "false"
         ),
         "is_research_survey_optional": (
             "true"
             if round.feedback_survey_config
-            and round.feedback_survey_config.get("is_research_survey_optional", "") == "true"
+               and round.feedback_survey_config.get("is_research_survey_optional", "") == "true"
             else "false"
         ),
         "eligibility_config": (

--- a/app/blueprints/fund_builder/routes.py
+++ b/app/blueprints/fund_builder/routes.py
@@ -40,11 +40,11 @@ from app.db.queries.application import move_form_up
 from app.db.queries.application import move_section_down
 from app.db.queries.application import move_section_up
 from app.db.queries.application import update_section
-from app.db.queries.fund import add_fund, get_fund_by_short_name
+from app.db.queries.fund import add_fund
 from app.db.queries.fund import get_all_funds
 from app.db.queries.fund import get_fund_by_id
 from app.db.queries.fund import update_fund
-from app.db.queries.round import add_round, get_round_by_short_name_and_fund_id
+from app.db.queries.round import add_round
 from app.db.queries.round import get_round_by_id
 from app.db.queries.round import update_round
 from app.export_config.generate_all_questions import print_html
@@ -288,6 +288,7 @@ def fund(fund_id=None):
         add_fund(new_fund)
         flash(f"Created fund {form.name_en.data}")
         return redirect(url_for(BUILD_FUND_BP_DASHBOARD))
+
     error = error_formatter(form)
     return render_template("fund.html", form=form, fund_id=fund_id, error=error)
 
@@ -302,9 +303,11 @@ def round(round_id=None):
     form = RoundForm()
     params = {"all_funds": all_funds_as_govuk_select_items(get_all_funds())}
     params["selected_fund_id"] = request.form.get("fund_id", None)
+
     if round_id:
         round = get_round_by_id(round_id)
         form = populate_form_with_round_data(round)
+
     if form.validate_on_submit():
         if round_id:
             update_existing_round(round, form)
@@ -313,8 +316,10 @@ def round(round_id=None):
         create_new_round(form)
         flash(f"Created round {form.title_en.data}")
         return redirect(url_for(BUILD_FUND_BP_DASHBOARD))
+
     params["round_id"] = round_id
     params["form"] = form
+
     error = error_formatter(params["form"])
     return render_template("round.html", **params, error=error)
 
@@ -395,19 +400,19 @@ def populate_form_with_round_data(round):
         "is_feedback_survey_optional": (
             "true"
             if round.feedback_survey_config
-               and round.feedback_survey_config.get("is_feedback_survey_optional", "") == "true"
+            and round.feedback_survey_config.get("is_feedback_survey_optional", "") == "true"
             else "false"
         ),
         "is_section_feedback_optional": (
             "true"
             if round.feedback_survey_config
-               and round.feedback_survey_config.get("is_section_feedback_optional", "") == "true"
+            and round.feedback_survey_config.get("is_section_feedback_optional", "") == "true"
             else "false"
         ),
         "is_research_survey_optional": (
             "true"
             if round.feedback_survey_config
-               and round.feedback_survey_config.get("is_research_survey_optional", "") == "true"
+            and round.feedback_survey_config.get("is_research_survey_optional", "") == "true"
             else "false"
         ),
         "eligibility_config": (

--- a/app/blueprints/fund_builder/routes.py
+++ b/app/blueprints/fund_builder/routes.py
@@ -288,7 +288,7 @@ def fund(fund_id=None):
         add_fund(new_fund)
         flash(f"Created fund {form.name_en.data}")
         return redirect(url_for(BUILD_FUND_BP_DASHBOARD))
-    error = error_formatter(form.errors)
+    error = error_formatter(form)
     return render_template("fund.html", form=form, fund_id=fund_id, error=error)
 
 
@@ -315,7 +315,7 @@ def round(round_id=None):
         return redirect(url_for(BUILD_FUND_BP_DASHBOARD))
     params["round_id"] = round_id
     params["form"] = form
-    error = error_formatter(params["form"].errors)
+    error = error_formatter(params["form"])
     return render_template("round.html", **params, error=error)
 
 

--- a/app/blueprints/templates/routes.py
+++ b/app/blueprints/templates/routes.py
@@ -91,7 +91,7 @@ def view_templates():
 
     error = None
     if "uploadform" in params:
-        error = error_formatter(params["uploadform"].errors)
+        error = error_formatter(params["uploadform"])
     return render_template("view_templates.html", **params, error=error)
 
 
@@ -120,7 +120,7 @@ def edit_form_template(form_id):
         params["template_form"] = template_form
         error = None
         if "template_form" in params:
-            error = error_formatter(params["template_form"].errors)
+            error = error_formatter(params["template_form"])
         return render_template("edit_form_template.html", **params, error=error)
 
     if request.args.get("action") == "remove":

--- a/app/db/queries/fund.py
+++ b/app/db/queries/fund.py
@@ -35,3 +35,7 @@ def get_fund_by_id(id: str) -> Fund:
     if not fund:
         raise ValueError(f"Fund with id {id} not found")
     return fund
+
+
+def get_fund_by_short_name(short_name: str) -> Fund:
+    return db.session.query(Fund).filter_by(short_name=short_name).first()

--- a/app/db/queries/round.py
+++ b/app/db/queries/round.py
@@ -25,6 +25,10 @@ def get_round_by_id(id: str) -> Round:
     return round
 
 
+def get_round_by_short_name_and_fund_id(fund_id: str, short_name: str) -> Round:
+    return db.session.query(Round).filter_by(fund_id=fund_id, short_name=short_name).first()
+
+
 def get_all_rounds() -> list:
     stmt = select(Round).order_by(Round.short_name)
     return db.session.scalars(stmt).all()

--- a/app/shared/helpers.py
+++ b/app/shared/helpers.py
@@ -43,15 +43,15 @@ def get_all_pages_in_parent_form(db, page_id):
 
 # This formatter will read all the errors and then convert them to the required format to support error-summary display
 def error_formatter(form):
-    errorsList = []
+    errors_list = []
     for field, error_messages in form.errors.items():
         field_name = getattr(form, field).label.text
         if isinstance(error_messages, list):
-            errorsList.extend({"text": f"{field_name}: {err}", "href": f"#{field}"} for err in error_messages)
+            errors_list.extend({"text": f"{field_name}: {err}", "href": f"#{field}"} for err in error_messages)
         elif isinstance(error_messages, dict) and any(error_messages.get(k) for k in ["day", "month", "years", "hour", "minute"]):
-            errorsList.append({"text": f"{field_name}: Enter valid datetime", "href": f"#{field}"})
-    if errorsList:
-        return {"titleText": "There is a problem", "errorList": errorsList}
+            errors_list.append({"text": f"{field_name}: Enter valid datetime", "href": f"#{field}"})
+    if errors_list:
+        return {"titleText": "There is a problem", "errorList": errors_list}
     return None
 
 

--- a/app/shared/helpers.py
+++ b/app/shared/helpers.py
@@ -43,21 +43,17 @@ def get_all_pages_in_parent_form(db, page_id):
 
 # This formatter will read all the errors and then convert them to the required format to support error-summary display
 def error_formatter(form):
-    errors = form.errors
-    error = None
-    if errors:
-        errorsList = []
-        for field, errors in errors.items():
-            field_name = getattr(form, field).label.text
-            if isinstance(errors, list):
-                errorsList.extend([{"text": f"{field_name}: {err}", "href": f"#{field}"} for err in errors])
-            elif isinstance(errors, dict):
-                # Check if any of the datetime fields have errors
-                if any(len(errors.get(key, "")) > 0 for key in ["day", "month", "years", "hour", "minute"]):
-                    errorsList.append({"text": f"{field_name}: Enter valid datetime", "href": f"#{field}"})
-        if errorsList:
-            error = {"titleText": "There is a problem", "errorList": errorsList}
-    return error
+    errorsList = []
+    for field, error_messages in form.errors.items():
+        field_name = getattr(form, field).label.text
+        if isinstance(error_messages, list):
+            errorsList.extend({"text": f"{field_name}: {err}", "href": f"#{field}"} for err in error_messages)
+        elif isinstance(error_messages, dict) and any(error_messages.get(k) for k in ["day", "month", "years", "hour", "minute"]):
+            errorsList.append({"text": f"{field_name}: Enter valid datetime", "href": f"#{field}"})
+    if errorsList:
+        return {"titleText": "There is a problem", "errorList": errorsList}
+    return None
+
 
 
 # Custom validator to check for spaces between letters

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -110,7 +110,7 @@ def test_create_fund_with_existing_short_name(flask_test_client):
     response = submit_form(flask_test_client, "/fund", create_data)
     assert response.status_code == 200
     html = response.data.decode('utf-8')
-    assert  '<a href="#short_name">Given fund short name already exists.</a>' in html, "Not having the fund short name already exists error"
+    assert  '<a href="#short_name">Short name: Given fund short name already exists.</a>' in html, "Not having the fund short name already exists error"
 
 
 @pytest.mark.usefixtures("set_auth_cookie", "patch_validate_token_rs256_internal_user")
@@ -205,7 +205,7 @@ def test_create_round_with_existing_short_name(flask_test_client, seed_dynamic_d
     response = submit_form(flask_test_client, "/round", new_round_data)
     assert response.status_code == 200
     html = response.data.decode('utf-8')
-    assert  '<a href="#short_name">Given short name already exists in the fund funding to improve testing.</a>' in html, "Not having the fund round short name already exists error"
+    assert  '<a href="#short_name">Short name: Given short name already exists in the fund funding to improve testing.</a>' in html, "Not having the fund round short name already exists error"
 
 
 @pytest.mark.usefixtures("set_auth_cookie", "patch_validate_token_rs256_internal_user")

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -196,17 +196,24 @@ def test_create_round_with_existing_short_name(flask_test_client, seed_dynamic_d
         "guidance_url": "http://example.com/guidance",
     }
 
+    error_html = '<a href="#short_name">Short name: Given short name already exists in the fund funding to improve testing.</a>'
+
+    # Test works fine with first round
     response = submit_form(flask_test_client, "/round", new_round_data)
     assert response.status_code == 200
+    assert error_html not in response.data.decode('utf-8'), "Error HTML found in response"
+
+    # Test works fine with second round but with different short name
     new_round_data = {**new_round_data, 'short_name': 'NR1234'}
     response = submit_form(flask_test_client, "/round", new_round_data)
     assert response.status_code == 200
+    assert error_html not in response.data.decode('utf-8'), "Error HTML found in response"
+
+    # Test doesn't work with third round with same short name as firsrt
     new_round_data = {**new_round_data, 'short_name': 'NR123'}
     response = submit_form(flask_test_client, "/round", new_round_data)
     assert response.status_code == 200
-    html = response.data.decode('utf-8')
-    assert  '<a href="#short_name">Short name: Given short name already exists in the fund funding to improve testing.</a>' in html, "Not having the fund round short name already exists error"
-
+    assert error_html in response.data.decode('utf-8'), "Error HTML not found in response"
 
 @pytest.mark.usefixtures("set_auth_cookie", "patch_validate_token_rs256_internal_user")
 def test_create_new_round(flask_test_client, seed_dynamic_data):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -82,6 +82,38 @@ def test_create_fund(flask_test_client):
 
 
 @pytest.mark.usefixtures("set_auth_cookie", "patch_validate_token_rs256_internal_user")
+def test_create_fund_with_existing_short_name(flask_test_client):
+    """
+    Tests that a fund can be successfully created using the /fund route
+    Verifies that the created fund has the correct attributes
+    """
+    create_data = {
+        "name_en": "New Fund 2",
+        "title_en": "New Fund Title 2",
+        "description_en": "New Fund Description 2",
+        "welsh_available": "false",
+        "short_name": "SMP1",
+        "funding_type": FundingType.COMPETITIVE.value,
+        "ggis_scheme_reference_number": "G1-SCH-0000092415",
+    }
+    response = submit_form(flask_test_client, "/fund", create_data)
+    assert response.status_code == 200
+    create_data = {
+        "name_en": "New Fund 3",
+        "title_en": "New Fund Title 3",
+        "description_en": "New Fund Description 3",
+        "welsh_available": "false",
+        "short_name": "SMP1",
+        "funding_type": FundingType.COMPETITIVE.value,
+        "ggis_scheme_reference_number": "G1-SCH-0000092415",
+    }
+    response = submit_form(flask_test_client, "/fund", create_data)
+    assert response.status_code == 200
+    html = response.data.decode('utf-8')
+    assert  '<a href="#short_name">Given fund short name already exists.</a>' in html, "Not having the fund short name already exists error"
+
+
+@pytest.mark.usefixtures("set_auth_cookie", "patch_validate_token_rs256_internal_user")
 def test_update_fund(flask_test_client, seed_dynamic_data):
     """
     Tests that a fund can be successfully updated using the /fund/<fund_id> route
@@ -114,6 +146,66 @@ def test_update_fund(flask_test_client, seed_dynamic_data):
             assert updated_fund.funding_type.value == value
         elif key != "submit":
             assert updated_fund.__getattribute__(key) == value
+
+@pytest.mark.usefixtures("set_auth_cookie", "patch_validate_token_rs256_internal_user")
+def test_create_round_with_existing_short_name(flask_test_client, seed_dynamic_data):
+    """
+    Tests that a round can be successfully created using the /round route
+    Verifies that the created round has the correct attributes
+    """
+    test_fund = seed_dynamic_data["funds"][0]
+    new_round_data = {
+        "fund_id": test_fund.fund_id,
+        "title_en": "New Round",
+        "short_name": "NR123",
+        "opens-day": "01",
+        "opens-month": "10",
+        "opens-year": "2024",
+        "opens-hour": "09",
+        "opens-minute": "00",
+        "deadline-day": "01",
+        "deadline-month": "12",
+        "deadline-year": "2024",
+        "deadline-hour": "17",
+        "deadline-minute": "00",
+        "assessment_start-day": "02",
+        "assessment_start-month": "12",
+        "assessment_start-year": "2024",
+        "assessment_start-hour": "09",
+        "assessment_start-minute": "00",
+        "reminder_date-day": "15",
+        "reminder_date-month": "11",
+        "reminder_date-year": "2024",
+        "reminder_date-hour": "09",
+        "reminder_date-minute": "00",
+        "assessment_deadline-day": "15",
+        "assessment_deadline-month": "12",
+        "assessment_deadline-year": "2024",
+        "assessment_deadline-hour": "17",
+        "assessment_deadline-minute": "00",
+        "prospectus_link": "http://example.com/prospectus",
+        "privacy_notice_link": "http://example.com/privacy",
+        "contact_email": "contact@example.com",
+        "submit": "Submit",
+        "contact_phone": "1234567890",
+        "contact_textphone": "0987654321",
+        "support_times": "9am - 5pm",
+        "support_days": "Monday to Friday",
+        "feedback_link": "http://example.com/feedback",
+        "project_name_field_id": 1,
+        "guidance_url": "http://example.com/guidance",
+    }
+
+    response = submit_form(flask_test_client, "/round", new_round_data)
+    assert response.status_code == 200
+    new_round_data = {**new_round_data, 'short_name': 'NR1234'}
+    response = submit_form(flask_test_client, "/round", new_round_data)
+    assert response.status_code == 200
+    new_round_data = {**new_round_data, 'short_name': 'NR123'}
+    response = submit_form(flask_test_client, "/round", new_round_data)
+    assert response.status_code == 200
+    html = response.data.decode('utf-8')
+    assert  '<a href="#short_name">Given short name already exists in the fund funding to improve testing.</a>' in html, "Not having the fund round short name already exists error"
 
 
 @pytest.mark.usefixtures("set_auth_cookie", "patch_validate_token_rs256_internal_user")


### PR DESCRIPTION
**Ticket: https://mhclgdigital.atlassian.net/browse/FS-4895**


### Change description
In this change we are focussing on fund and round short name reuse issue so following scenarios are acceptable 

1. If there is a fund and that given short name is not in our records that short name is acceptable 
2. If there is an update for the given fund short name is acceptable because it belongs to it self 
3. IF there is a fund and when round creation if the short name is not available then acceptable 
4. IF there is a different fund and we are planing to use same short name it is acceptable 
5. If we do update the round then it will be again acceptable since short name belongs to it self

Following are not acceptable 

1. If there is a fund for a given short name then we are shoving an error for validation purpose 
2. If there is a fund and inside that fund if we have same short name round we give an error 

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test

**Testing Fund create**

1. Use FAB 
2. Try to create a fund that does not exists then it should show the success 
3. Try to create a existing short named fund it gives error
4. Try to rename a short name of a fund to a already existing one then it should give an error other wise should be success

**Testing Round Create**

1. Use FAB
2. Try to rename a short name of a round to a already existing one then it should give an error other wise should be success


### Screenshots of UI changes (if applicable)

![image](https://github.com/user-attachments/assets/bf58d6a9-3bfd-48db-8d6a-f324ad34c184)


![image](https://github.com/user-attachments/assets/88200f45-7528-49be-bfc5-bf54ff772914)

