### PR TITLE
FS-4833 - Adding basic auth to FAB

### DIFF
--- a/copilot/fsd-fund-application-builder/manifest.yml
+++ b/copilot/fsd-fund-application-builder/manifest.yml
@@ -64,9 +64,41 @@ environments:
   dev:
     count:
       spot: 1
+    sidecars:
+      nginx:
+        port: 8087
+        image:
+          location: xscys/nginx-sidecar-basic-auth
+        variables:
+          FORWARD_PORT: 8080
+          CLIENT_MAX_BODY_SIZE: 10m
+        secrets:
+          BASIC_AUTH_USERNAME: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_USERNAME
+          BASIC_AUTH_PASSWORD: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_PASSWORD
+    http:
+      target_container: nginx
+      healthcheck:
+        path: /healthcheck
+        port: 8080
   test:
     count:
       spot: 2
+    sidecars:
+      nginx:
+        port: 8087
+        image:
+          location: xscys/nginx-sidecar-basic-auth
+        variables:
+          FORWARD_PORT: 8080
+          CLIENT_MAX_BODY_SIZE: 10m
+        secrets:
+          BASIC_AUTH_USERNAME: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_USERNAME
+          BASIC_AUTH_PASSWORD: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_PASSWORD
+    http:
+      target_container: nginx
+      healthcheck:
+        path: /healthcheck
+        port: 8080
   uat:
     count:
       range: 2-4


### PR DESCRIPTION
### Ticket

[Add basic auth to FAB for pre-prod environments](https://mhclgdigital.atlassian.net/browse/FS-4833)

### Description

Following the convention of other apps including [Authenticator](https://github.com/communitiesuk/funding-service-design-authenticator/pull/358/files), we can use an Nginx sidecar to seamlessly provide basic auth on all HTTP requests, while allowing requests to `/healthcheck` through.

We have only added to Dev and Test environments, not UAT as this will be our _de facto_ prod environment for the January delivery, and will be authenticated by Entra ID.

Note that we also need to ensure values are in the AWS Parameter Store to support this change.