### PR TITLE
BAU - Add page title of 'Fund Application Builder' by default

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -2,7 +2,7 @@
 {% from "govuk_frontend_jinja/components/breadcrumbs/macro.html" import govukBreadcrumbs %}
 {% set assetPath = url_for('static', filename='').rstrip('/') %}
 
-{% block pageTitle %}{{ [pageHeading.rstrip('\n'), service_title]|join(' – ') if pageHeading else service_title }}{% endblock pageTitle %}
+{% block pageTitle %}Fund Application Builder{% endblock pageTitle %}
 
 {% block head %}
   {% include "head.html" %}


### PR DESCRIPTION
Currently we have no page title at all as neither `service_title` nor `pageHeading` are set anywhere. The code is effectively broken. This is just a very quick and hopefully uncontroversial fix to set "Fund Application Builder" as the page title in the base template.