### PR TITLE
Fix template paths for pre-award-frontend

### DIFF
--- a/app/export_config/generate_all_questions.py
+++ b/app/export_config/generate_all_questions.py
@@ -5,11 +5,11 @@ air = Airium()
 
 # Define start and end html
 BOILERPLATE_START = """
-{% extends "base.html" %}
+{% extends "apply/base.html" %}
 {%- from 'govuk_frontend_jinja/components/inset-text/macro.html' import govukInsetText -%}
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 
-{% from "partials/file-formats.html" import file_formats %}
+{% from "apply/partials/file-formats.html" import file_formats %}
 {% set pageHeading %}{% trans %}Full list of application questions{% endtrans %}{% endset %}
 {% block content %}
 <div class="govuk-grid-row">

--- a/app/export_config/generate_fund_round_html.py
+++ b/app/export_config/generate_fund_round_html.py
@@ -8,11 +8,11 @@ from app.export_config.generate_form import build_form_json
 from app.export_config.helpers import write_config
 
 frontend_html_prefix = """
-{% extends "base.html" %}
+{% extends "apply/base.html" %}
 {%- from 'govuk_frontend_jinja/components/inset-text/macro.html' import govukInsetText -%}
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 
-{% from "partials/file-formats.html" import file_formats %}
+{% from "apply/partials/file-formats.html" import file_formats %}
 {% set pageHeading %}{% trans %}Full list of application questions{% endtrans %}{% endset %}
 {% block content %}
 <div class="govuk-grid-row">
@@ -70,4 +70,10 @@ def generate_all_round_html(round_id, base_output_dir=None):
     html_content = frontend_html_prefix
     html_content += print_html(print_data)
     html_content += frontend_html_suffix
-    write_config(html_content, f"{fund.short_name.casefold()}_{round.short_name.casefold()}", round.short_name, "html", base_output_dir)
+    write_config(
+        html_content,
+        f"{fund.short_name.casefold()}_{round.short_name.casefold()}",
+        round.short_name,
+        "html",
+        base_output_dir,
+    )


### PR DESCRIPTION
We've moved apply, assess and authenticator into a single app. In doing so, to keep templates separate, we've namespaced them based on which app they came from.

So all apply frontend templates are now under the `apply/` prefix.

This fixes those template paths.