### PR TITLE
FS-4921 - Change service title to 'Fund Application Builder' and hyperlink it

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -11,7 +11,8 @@
 {% block header %}
   {{ govukHeader({
     'useTudorCrown': 'yes',
-    'serviceName': 'FSD Pre Award Proof of Concept'
+    'serviceName': 'Fund Application Builder',
+    'serviceUrl': url_for('build_fund_bp.index'),
   }) }}
 {% endblock header %}
 


### PR DESCRIPTION
### Ticket

[Change service title to Fund Application Builder](https://mhclgdigital.atlassian.net/browse/FS-4921)

### How to test

- Spin up FAB locally using [Docker Runner](https://github.com/communitiesuk/funding-service-design-docker-runner)
- Open FAB at https://fund-application-builder.levellingup.gov.localhost:3011/dashboard
- Note the title "Fund Application Builder"
- Click the title
- You should be redirected to either [login](https://fund-application-builder.levellingup.gov.localhost:3011/login) or [dashboard](https://fund-application-builder.levellingup.gov.localhost:3011/dashboard), depending on whether you are authenticated

### Screenshot

![image](https://github.com/user-attachments/assets/d4456442-43b2-4e2d-b13b-a1ac98acd063)