### PR TITLE
FS-4922 - Handle 500 error gracefully with error page render

### DIFF
--- a/app/create_app.py
+++ b/app/create_app.py
@@ -73,6 +73,10 @@ def create_app() -> Flask:
     def forbidden_error(error):
         return render_template("403.html"), 403
 
+    @flask_app.errorhandler(500)
+    def internal_server_error(e):
+        return render_template("500.html"), 500
+
     health = Healthcheck(flask_app)
     health.add_check(FlaskRunningChecker())
 

--- a/app/templates/500.html
+++ b/app/templates/500.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
+    <p class="govuk-body">Please try again later.</p>
+    <p class="govuk-body">If you continue to have issues, please contact your administrator.</p>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
### Ticket

https://mhclgdigital.atlassian.net/browse/FS-4922

### Description

Adds default error handler to application to catch all internal server errors and render a new 500.html page, which looks like this:

![image](https://github.com/user-attachments/assets/103835e2-76e7-45c7-a4b8-55eb14adab45)
