### PR TITLE
FS-4947 - Implement Flask-Talisman security headers

### DIFF
--- a/app/blueprints/fund/templates/fund.html
+++ b/app/blueprints/fund/templates/fund.html
@@ -44,30 +44,5 @@
     </div>
 </div>
 
-<script>
-function toggleWelshFields() {
-    const welshAvailable = document.querySelector('input[name="welsh_available"]:checked').value;
-    const welshFields = document.querySelectorAll('.welsh-field');
-
-    welshFields.forEach(field => {
-        const fieldContainer = field.closest('.govuk-form-group');
-        if (welshAvailable === 'true') {
-            fieldContainer.style.display = 'block';
-        } else {
-            fieldContainer.style.display = 'none';
-        }
-    });
-}
-
-// Run on page load
-document.addEventListener('DOMContentLoaded', function() {
-    toggleWelshFields();
-
-    // Add change event listeners to radio buttons
-    const radios = document.querySelectorAll('input[name="welsh_available"]');
-    radios.forEach(radio => {
-        radio.addEventListener('change', toggleWelshFields);
-    });
-});
-</script>
+<script src="{{ url_for('static', filename='js/create_edit_fund.js') }}"></script>
 {% endblock content %}

--- a/app/blueprints/round/templates/round.html
+++ b/app/blueprints/round/templates/round.html
@@ -74,25 +74,6 @@
     </div>
 </div>
 
-<script>
-// Store Welsh availability mapping passed from the route handler
-const isWelshAvailable = {{ fund.welsh_available | safe }};
-
-function toggleWelshFields() {
-    const welshFields = document.querySelectorAll('.welsh-field');
-    welshFields.forEach(field => {
-        const fieldContainer = field.closest('.govuk-form-group');
-        if (isWelshAvailable) {
-            fieldContainer.style.display = 'block';
-        } else {
-            fieldContainer.style.display = 'none';
-        }
-    });
-}
-
-// Run on page load
-document.addEventListener('DOMContentLoaded', function() {
-    toggleWelshFields();
-});
-</script>
+<div id="round-config" data-welsh-available="{{ fund.welsh_available | string | lower }}"></div>
+<script src="{{ url_for('static', filename='js/create_edit_round.js') }}"></script>
 {% endblock content %}

--- a/app/create_app.py
+++ b/app/create_app.py
@@ -1,4 +1,5 @@
 from flask import Flask, render_template
+from flask_talisman import Talisman
 from fsd_utils import init_sentry
 from fsd_utils.authentication.decorators import SupportedApp, check_internal_user, login_required
 from fsd_utils.healthchecks.checkers import FlaskRunningChecker
@@ -11,6 +12,7 @@ from app.blueprints.fund.routes import fund_bp
 from app.blueprints.index.routes import index_bp
 from app.blueprints.round.routes import round_bp
 from app.blueprints.template.routes import template_bp
+from config import Config
 
 PUBLIC_ROUTES = [
     "static",
@@ -48,6 +50,7 @@ def create_app() -> Flask:
 
     # Bind SQLAlchemy ORM to Flask app
     db.init_app(flask_app)
+
     # Bind Flask-Migrate db utilities to Flask app
     migrate.init_app(
         flask_app,
@@ -57,6 +60,9 @@ def create_app() -> Flask:
         compare_type=True,
         compare_server_default=True,
     )
+
+    # Configure application security with Talisman
+    Talisman(flask_app, **Config.TALISMAN_SETTINGS)
 
     # Initialise logging
     logging.init_app(flask_app)

--- a/app/static/src/js/create_edit_fund.js
+++ b/app/static/src/js/create_edit_fund.js
@@ -1,0 +1,24 @@
+function toggleWelshFields() {
+    const welshAvailable = document.querySelector('input[name="welsh_available"]:checked').value;
+    const welshFields = document.querySelectorAll('.welsh-field');
+
+    welshFields.forEach(field => {
+        const fieldContainer = field.closest('.govuk-form-group');
+        if (welshAvailable === 'true') {
+            fieldContainer.style.display = 'block';
+        } else {
+            fieldContainer.style.display = 'none';
+        }
+    });
+}
+
+// Run on page load
+document.addEventListener('DOMContentLoaded', function() {
+    toggleWelshFields();
+
+    // Add change event listeners to radio buttons
+    const radios = document.querySelectorAll('input[name="welsh_available"]');
+    radios.forEach(radio => {
+        radio.addEventListener('change', toggleWelshFields);
+    });
+});

--- a/app/static/src/js/create_edit_round.js
+++ b/app/static/src/js/create_edit_round.js
@@ -1,0 +1,19 @@
+function toggleWelshFields() {
+    // Get the welsh availability from the data attribute
+    const isWelshAvailable = document.getElementById('round-config').dataset.welshAvailable === 'true';
+
+    const welshFields = document.querySelectorAll('.welsh-field');
+    welshFields.forEach(field => {
+        const fieldContainer = field.closest('.govuk-form-group');
+        if (isWelshAvailable) {
+            fieldContainer.style.display = 'block';
+        } else {
+            fieldContainer.style.display = 'none';
+        }
+    });
+}
+
+// Run on page load
+document.addEventListener('DOMContentLoaded', function() {
+    toggleWelshFields();
+});

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -2,6 +2,8 @@
 {% from "govuk_frontend_jinja/components/breadcrumbs/macro.html" import govukBreadcrumbs %}
 {% set assetPath = url_for("static", filename="").rstrip("/") %}
 
+{% set cspNonce = csp_nonce() %}  {# Used in the base template govuk_frontend_jinja/template.html #}
+
 {% block pageTitle %}Fund Application Builder{% endblock pageTitle %}
 
 {% block head %}
@@ -37,7 +39,7 @@
 
 {% block bodyEnd %}
   <script type="module" src="{{ url_for('static', filename='govuk-frontend/govuk-frontend-5.6.0.min.js') }}"></script>
-  <script type="module">
+  <script type="module" nonce="{{ csp_nonce() }}">
     import { initAll } from "{{ url_for('static', filename='govuk-frontend/govuk-frontend-5.6.0.min.js') }}"
     initAll()
   </script>

--- a/app/templates/head.html
+++ b/app/templates/head.html
@@ -4,7 +4,3 @@
 
 <link rel="stylesheet" type="text/css"
     href="{{ url_for('static', filename='styles/fab.css') }}" />
-
-
-<!-- jsDelivr :: Sortable :: Latest (https://www.jsdelivr.com/package/npm/sortablejs) -->
-<script src="https://cdn.jsdelivr.net/npm/sortablejs@latest/Sortable.min.js"></script>

--- a/build.py
+++ b/build.py
@@ -5,6 +5,18 @@ import urllib.request
 import zipfile
 
 
+def copy_static_files(src_subdir, dist_subdir, file_pattern="*.*"):
+    """Generic function to copy static files from src to dist"""
+    src_dir = f"./app/static/src/{src_subdir}"
+    dist_dir = f"./app/static/dist/{src_subdir}"
+
+    if os.path.exists(src_dir):
+        os.makedirs(dist_dir, exist_ok=True)
+        for file in glob.glob(os.path.join(src_dir, file_pattern)):
+            print(f"Copying {file} to {dist_dir}")
+            shutil.copy2(file, dist_dir)
+
+
 def build_govuk_assets(static_dist_root="app/static/dist"):
     DIST_ROOT = "./" + static_dist_root
     GOVUK_DIR = "/govuk-frontend"
@@ -16,7 +28,7 @@ def build_govuk_assets(static_dist_root="app/static/dist"):
 
     # Checks if GovUK Frontend Assets already built
     if os.path.exists(DIST_PATH):
-        print("GovUK Frontend assets already built.If you require a rebuild manually run build.build_govuk_assets")
+        print("GovUK Frontend assets already built. If you require a rebuild manually run build.build_govuk_assets")
         return True
 
     # Download zips from GOVUK_URL
@@ -66,13 +78,6 @@ def build_govuk_assets(static_dist_root="app/static/dist"):
             file.write(filedata)
     os.chdir(cwd)
 
-    # Copy css
-    os.makedirs("./app/static/dist/styles")
-    shutil.copyfile("./app/static/src/styles/fab.css", "./app/static/dist/styles/fab.css")
-
-    # Copy over JS source
-    os.makedirs("./app/static/dist/js")
-
     # Delete temp files
     print("Deleting " + ASSETS_PATH)
     shutil.rmtree(ASSETS_PATH)
@@ -85,6 +90,8 @@ def build_all(static_dist_root="app/static/dist", remove_existing=False):
         if os.path.exists(relative_dist_root):
             shutil.rmtree(relative_dist_root)
     build_govuk_assets(static_dist_root=static_dist_root)
+    copy_static_files("styles", "styles", "*.css")
+    copy_static_files("js", "js", "*.js")
 
 
 if __name__ == "__main__":

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -34,11 +34,7 @@ class DefaultConfig(object):
     # Content Security Policy
     SECURE_CSP = {
         "default-src": "'self'",
-        "script-src": [
-            "'self'",
-            "'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw='",
-            "'sha256-0F02u9outG+s4SWeWHc/Pmk8iJNh7GtqrTtLPzkxZ3M='",
-        ],
+        "script-src": ["'self'"],  # Needed to enable nonce
     }
 
     # Talisman Config
@@ -75,7 +71,6 @@ class DefaultConfig(object):
         "content_security_policy": SECURE_CSP,
         "content_security_policy_report_uri": None,
         "content_security_policy_report_only": False,
-        # "content_security_policy_nonce_in": None,
         "referrer_policy": FSD_REFERRER_POLICY,
         "session_cookie_secure": True,
         "session_cookie_http_only": True,

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -30,3 +30,57 @@ class DefaultConfig(object):
     RSA256_PUBLIC_KEY_BASE64 = getenv("RSA256_PUBLIC_KEY_BASE64")
     if RSA256_PUBLIC_KEY_BASE64:
         RSA256_PUBLIC_KEY: str = base64.b64decode(RSA256_PUBLIC_KEY_BASE64).decode()
+
+    # Content Security Policy
+    SECURE_CSP = {
+        "default-src": "'self'",
+        "script-src": [
+            "'self'",
+            "'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw='",
+            "'sha256-0F02u9outG+s4SWeWHc/Pmk8iJNh7GtqrTtLPzkxZ3M='",
+        ],
+    }
+
+    # Talisman Config
+    FSD_REFERRER_POLICY = "strict-origin-when-cross-origin"
+    FSD_USER_TOKEN_COOKIE_SAMESITE = "Lax"
+    FSD_SESSION_COOKIE_SAMESITE = "Lax"
+    FSD_PERMISSIONS_POLICY = {"interest-cohort": "()"}
+    FSD_DOCUMENT_POLICY = {}
+    FSD_FEATURE_POLICY = {
+        "microphone": "'none'",
+        "camera": "'none'",
+        "geolocation": "'none'",
+    }
+
+    DENY = "DENY"
+    SAMEORIGIN = "SAMEORIGIN"
+    ALLOW_FROM = "ALLOW-FROM"
+    ONE_YEAR_IN_SECS = 31556926
+    FORCE_HTTPS = False
+
+    TALISMAN_SETTINGS = {
+        "feature_policy": FSD_FEATURE_POLICY,
+        "permissions_policy": FSD_PERMISSIONS_POLICY,
+        "document_policy": FSD_DOCUMENT_POLICY,
+        "force_https": FORCE_HTTPS,
+        "force_https_permanent": False,
+        "force_file_save": False,
+        "frame_options": "SAMEORIGIN",
+        "frame_options_allow_from": None,
+        "strict_transport_security": True,
+        "strict_transport_security_preload": True,
+        "strict_transport_security_max_age": ONE_YEAR_IN_SECS,
+        "strict_transport_security_include_subdomains": True,
+        "content_security_policy": SECURE_CSP,
+        "content_security_policy_report_uri": None,
+        "content_security_policy_report_only": False,
+        # "content_security_policy_nonce_in": None,
+        "referrer_policy": FSD_REFERRER_POLICY,
+        "session_cookie_secure": True,
+        "session_cookie_http_only": True,
+        "session_cookie_samesite": FSD_SESSION_COOKIE_SAMESITE,
+        "x_content_type_options": True,
+        "x_xss_protection": True,
+        "content_security_policy_nonce_in": ["script-src"],
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "flask-sqlalchemy==3.1.1",
     "flask-wtf==1.2.2",
     "flask==3.1.0",
+    "flask-talisman==1.1.0",
     "funding-service-design-utils==5.2.0",
     "govuk-frontend-jinja==3.4.0",
     "jsonschema==4.23.0",

--- a/uv.lock
+++ b/uv.lock
@@ -103,7 +103,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
-    { name = "urllib3" },
+    { name = "urllib3", marker = "python_full_version >= '3.10.0' and python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8c/66/01d63edf404b2ef2c5594701565ac0c031ce7253231298d423e2514566b8/botocore-1.34.144.tar.gz", hash = "sha256:4215db28d25309d59c99507f1f77df9089e5bebbad35f6e19c7c44ec5383a3e8", size = 12618703 }
 wheels = [
@@ -179,7 +179,7 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
 wheels = [
@@ -283,9 +283,9 @@ dependencies = [
     { name = "pathspec" },
     { name = "pyyaml" },
     { name = "regex" },
-    { name = "tomli" },
+    { name = "tomli", marker = "python_full_version >= '3.10.0' and python_full_version < '3.11'" },
     { name = "tqdm" },
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10.0' and python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/74/89/ecf5be9f5c59a0c53bcaa29671742c5e269cc7d0e2622e3f65f41df251bf/djlint-1.36.4.tar.gz", hash = "sha256:17254f218b46fe5a714b224c85074c099bcb74e3b2e1f15c2ddc2cf415a408a1", size = 47849 }
 wheels = [
@@ -392,6 +392,15 @@ wheels = [
 ]
 
 [[package]]
+name = "flask-talisman"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/5c/157d51e32eaffdb34ee316261239937d66400a57cd8146176fd8ce50c43a/flask-talisman-1.1.0.tar.gz", hash = "sha256:c5f486f5f54420729f84b3c3850cd63f96e8b033a9629bee66c524ea363797ff", size = 22656 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/1c/a15ac936dc3ae4491c5ff089dccdccd72cd3608b15fcf4e2de961f9ee8f3/flask_talisman-1.1.0-py2.py3-none-any.whl", hash = "sha256:3c42b610ebe49b0e35ca150e179bf51aa1da01e4635b49a674868ea681046208", size = 18967 },
+]
+
+[[package]]
 name = "flask-wtf"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -415,6 +424,7 @@ dependencies = [
     { name = "flask" },
     { name = "flask-migrate" },
     { name = "flask-sqlalchemy" },
+    { name = "flask-talisman" },
     { name = "flask-wtf" },
     { name = "funding-service-design-utils" },
     { name = "govuk-frontend-jinja" },
@@ -446,6 +456,7 @@ requires-dist = [
     { name = "flask", specifier = "==3.1.0" },
     { name = "flask-migrate", specifier = "==4.0.7" },
     { name = "flask-sqlalchemy", specifier = "==3.1.1" },
+    { name = "flask-talisman", specifier = "==1.1.0" },
     { name = "flask-wtf", specifier = "==1.2.2" },
     { name = "funding-service-design-utils", specifier = "==5.2.0" },
     { name = "govuk-frontend-jinja", specifier = "==3.4.0" },
@@ -687,7 +698,7 @@ version = "1.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mypy-extensions" },
-    { name = "tomli" },
+    { name = "tomli", marker = "python_full_version >= '3.10.0' and python_full_version < '3.11'" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/eb/2c92d8ea1e684440f54fa49ac5d9a5f19967b7b472a281f419e69a8d228e/mypy-1.14.1.tar.gz", hash = "sha256:7ec88144fe9b510e8475ec2f5f251992690fcf89ccb4500b214b4226abcd32d6", size = 3216051 }
@@ -829,11 +840,11 @@ version = "8.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "exceptiongroup" },
+    { name = "exceptiongroup", marker = "python_full_version >= '3.10.0' and python_full_version < '3.11'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
-    { name = "tomli" },
+    { name = "tomli", marker = "python_full_version >= '3.10.0' and python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
 wheels = [
@@ -846,7 +857,7 @@ version = "1.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
-    { name = "tomli" },
+    { name = "tomli", marker = "python_full_version >= '3.10.0' and python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/31/27f28431a16b83cab7a636dce59cf397517807d247caa38ee67d65e71ef8/pytest_env-1.1.5.tar.gz", hash = "sha256:91209840aa0e43385073ac464a554ad2947cc2fd663a9debf88d03b01e0cc1cf", size = 8911 }
 wheels = [
@@ -951,7 +962,7 @@ name = "redis"
 version = "4.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "async-timeout" },
+    { name = "async-timeout", marker = "python_full_version >= '3.10.0' and python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/73/88/63d802c2b18dd9eaa5b846cbf18917c6b2882f20efda398cc16a7500b02c/redis-4.6.0.tar.gz", hash = "sha256:585dc516b9eb042a619ef0a39c3d7d55fe81bdb4df09a52c9cdde0d07bf1aa7d", size = 4561721 }
 wheels = [
@@ -1136,7 +1147,7 @@ name = "sqlalchemy"
 version = "2.0.36"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "greenlet", marker = "(platform_machine == 'AMD64' and python_full_version >= '3.10.0' and python_full_version < '3.11') or (platform_machine == 'WIN32' and python_full_version >= '3.10.0' and python_full_version < '3.11') or (platform_machine == 'aarch64' and python_full_version >= '3.10.0' and python_full_version < '3.11') or (platform_machine == 'amd64' and python_full_version >= '3.10.0' and python_full_version < '3.11') or (platform_machine == 'ppc64le' and python_full_version >= '3.10.0' and python_full_version < '3.11') or (platform_machine == 'win32' and python_full_version >= '3.10.0' and python_full_version < '3.11') or (platform_machine == 'x86_64' and python_full_version >= '3.10.0' and python_full_version < '3.11')" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/65/9cbc9c4c3287bed2499e05033e207473504dc4df999ce49385fb1f8b058a/sqlalchemy-2.0.36.tar.gz", hash = "sha256:7f2767680b6d2398aea7082e45a774b2b0767b5c8d8ffb9c8b683088ea9b29c5", size = 9574485 }
@@ -1183,7 +1194,7 @@ name = "tqdm"
 version = "4.66.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5a/c0/b7599d6e13fe0844b0cda01b9aaef9a0e87dbb10b06e4ee255d3fa1c79a2/tqdm-4.66.4.tar.gz", hash = "sha256:e4d936c9de8727928f3be6079590e97d9abfe8d39a590be678eb5919ffc186bb", size = 169392 }
 wheels = [


### PR DESCRIPTION
### Ticket
[FS-4947](https://mhclgdigital.atlassian.net/browse/FS-4947)

### Changes made

- **Remove unused Sortable.js** - Removed an unused script that was being loaded from an external CDN. We don't want to include it as a safe script source in our Flask-Talisman Content Security Policy (CSP)
- **Move inline JavaScript to files** - Replaced inline JavaScript with external file references in the templates for creating and editing Fund and Round and modified the static asset build process to handle this. When using Flask-Talisman, inline JavaScript necessitates adding script hashes to the CSP, which is not maintainable
- **Add Flask-Talisman** - Implemented Flask-Talisman with settings copied from [Pre-Award](https://github.com/communitiesuk/funding-service-pre-award/blob/main/config/envs/default.py). Replaced Pre-Award sources in the CSP with ones specifically relevant to FAB

### Testing instructions

1. Content Security Policy

- Visit `/funds/create` or access an existing fund
- Toggle the "Welsh available" radio buttons
- Verify the Welsh fields appear/disappear smoothly with no console errors

This confirms our external JavaScript is correctly whitelisted in CSP while inline scripts are properly removed

2. Basic Security Headers

- Using browser developer tools, inspect response headers for any page
- Verify presence of:
  - Content-Security-Policy with default-src 'self'
  - X-Frame-Options: SAMEORIGIN
  - Referrer-Policy: strict-origin-when-cross-origin

This confirms Flask-Talisman is active with our configuration