### PR TITLE
FS-4927 - Adding error summary and errored field error decoration to intermediary 'Select fund' and 'Select application' pages

### DIFF
--- a/app/blueprints/application/forms.py
+++ b/app/blueprints/application/forms.py
@@ -1,5 +1,5 @@
 from flask_wtf import FlaskForm
-from wtforms import HiddenField, StringField
+from wtforms import HiddenField, SelectField, StringField
 from wtforms.validators import DataRequired
 
 
@@ -7,3 +7,9 @@ class SectionForm(FlaskForm):
     round_id = HiddenField("Round ID")
     section_id = HiddenField("Section ID")
     name_in_apply_en = StringField("Name", validators=[DataRequired()])
+
+
+class SelectApplicationForm(FlaskForm):
+    round_id = SelectField(
+        "Select or create an application", validators=[DataRequired(message="Select or create an application")]
+    )

--- a/app/shared/forms.py
+++ b/app/shared/forms.py
@@ -1,0 +1,7 @@
+from flask_wtf import FlaskForm
+from wtforms import SelectField
+from wtforms.validators import DataRequired
+
+
+class SelectFundForm(FlaskForm):
+    fund_id = SelectField("Select or add a grant", validators=[DataRequired(message="Select or add a grant")])

--- a/app/templates/select_application.html
+++ b/app/templates/select_application.html
@@ -2,6 +2,7 @@
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/select/macro.html" import govukSelect %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary %}
 
 
 {% block content %}
@@ -12,19 +13,26 @@
       "href": url_for("application_bp.select_fund")
     }) }}
 
+    {% if error %}
+      {{ govukErrorSummary({
+        "titleText": error.titleText,
+        "errorList": error.errorList,
+        "classes": "govuk-!-margin-bottom-4"
+      }) }}
+    {% endif %}
+
     <span class="govuk-caption-m">{{ fund.short_name + " - " + fund.title_json["en"] }}</span>
     <h1 class="govuk-heading-l">Select an application</h1>
     <p class="govuk-body">Select the application you want to manage or create a new one</p>
 
     <form method="POST">
+      {{ form.csrf_token }}
       {{ govukSelect({
-        "id": "round_id",
-        "name": "round_id",
-        "items": round_dropdown_items,
+        "id": form.round_id.id,
+        "name": form.round_id.name,
+        "items": select_items,
         "label": "",
-        "attributes": {
-          "required": "required"
-        },
+        "errorMessage": {"text": form.round_id.errors[0]} if form.round_id.errors else None,
         "classes": "govuk-!-width-one-half",
         "formGroup": {
           "classes": "govuk-!-margin-bottom-3"

--- a/app/templates/select_fund.html
+++ b/app/templates/select_fund.html
@@ -2,6 +2,7 @@
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/select/macro.html" import govukSelect %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary %}
 
 {% block content %}
 <div class="govuk-grid-row">
@@ -11,18 +12,25 @@
       "href": url_for("index_bp.dashboard")
     }) }}
 
+    {% if error %}
+      {{ govukErrorSummary({
+        "titleText": error.titleText,
+        "errorList": error.errorList,
+        "classes": "govuk-!-margin-bottom-4"
+      }) }}
+    {% endif %}
+
     <h1 class="govuk-heading-l">Select a grant</h1>
     <p class="govuk-body">Select or add a new grant for this application</p>
 
     <form method="POST">
+      {{ form.csrf_token }}
       {{ govukSelect({
-        "id": "fund_id",
-        "name": "fund_id",
-        "items": fund_dropdown_items,
+        "id": form.fund_id.id,
+        "name": form.fund_id.name,
+        "items": select_items,
         "label": "",
-        "attributes": {
-          "required": "required"
-        },
+        "errorMessage": {"text": form.fund_id.errors[0]} if form.fund_id.errors else None,
         "classes": "govuk-!-width-one-half",
         "formGroup": {
           "classes": "govuk-!-margin-bottom-3"

--- a/tests/blueprints/application/test_routes.py
+++ b/tests/blueprints/application/test_routes.py
@@ -1,6 +1,8 @@
 import pytest
 from flask import url_for
 
+from tests.helpers import submit_form
+
 
 @pytest.mark.usefixtures("set_auth_cookie", "patch_validate_token_rs256_internal_user")
 def test_select_fund(flask_test_client, seed_dynamic_data):
@@ -9,57 +11,50 @@ def test_select_fund(flask_test_client, seed_dynamic_data):
       1) A user cannot proceed without selecting a fund,
       2) A valid fund selection redirects to the select_application page.
     """
+    url = "/rounds/sections/select-grant"
+
     # Attempt to submit without a fund selected
-    with pytest.raises(ValueError, match="Fund ID is required to manage an application"):
-        flask_test_client.post(
-            "/rounds/sections/select-grant",
-            data={"fund_id": ""},
-            follow_redirects=True,
-        )
+    response = submit_form(flask_test_client, url, {"fund_id": ""})
+    assert response.status_code == 200  # Returns form with errors
+    assert b"There is a problem" in response.data  # Validation error message
 
     # Submit with a valid fund
     test_fund = seed_dynamic_data["funds"][0]
-    response = flask_test_client.post(
-        "/rounds/sections/select-grant", data={"fund_id": str(test_fund.fund_id)}, follow_redirects=False
-    )
+    response = submit_form(flask_test_client, url, {"fund_id": str(test_fund.fund_id)}, follow_redirects=False)
     assert response.status_code == 302
 
-    # Confirm redirect to the application_bp.select_application route
+    # Confirm redirect to /rounds/sections/select-application?fund_id=...
     expected_location = url_for("application_bp.select_application", fund_id=test_fund.fund_id)
     assert response.location == expected_location
 
 
 @pytest.mark.usefixtures("set_auth_cookie", "patch_validate_token_rs256_internal_user")
-def test_select_application(flask_test_client, seed_dynamic_data):
-    """
-    Test the /rounds/sections/select-application route to ensure:
-      1) A user cannot proceed without selecting an application,
-      2) A valid application selection redirects to the build_application page.
-    """
-    # Attempt to see the page without a fund ID
+def test_select_application_invalid_access(flask_test_client):
+    """Test that proper errors are raised for invalid access attempts"""
+    # Test access without fund ID
     with pytest.raises(ValueError, match="Fund ID is required to manage an application"):
         flask_test_client.get("/rounds/sections/select-application", follow_redirects=True)
 
-    # Attempt to see the page with an invalid fund ID
+    # Test access with invalid fund ID
     invalid_fund_id = "123e4567-e89b-12d3-a456-426614174000"
     with pytest.raises(ValueError, match=f"Fund with id {invalid_fund_id} not found"):
         flask_test_client.get(f"/rounds/sections/select-application?fund_id={invalid_fund_id}", follow_redirects=True)
 
+
+@pytest.mark.usefixtures("set_auth_cookie", "patch_validate_token_rs256_internal_user")
+def test_select_application_form_submission(flask_test_client, seed_dynamic_data):
+    """Test the actual form submission functionality"""
+    test_fund = seed_dynamic_data["funds"][0]
+    url = f"/rounds/sections/select-application?fund_id={test_fund.fund_id}"
+
     # Attempt to submit without a round selected
-    with pytest.raises(ValueError, match="Round ID is required to manage an application"):
-        flask_test_client.post(
-            "/rounds/sections/select-application",
-            data={"round_id": ""},
-            follow_redirects=True,
-        )
+    response = submit_form(flask_test_client, url, {"round_id": ""})
+    assert response.status_code == 200  # Returns form with errors
+    assert b"There is a problem" in response.data  # Validation error message
 
     # Submit with a valid round
     test_round = seed_dynamic_data["rounds"][0]
-    response = flask_test_client.post(
-        f"/rounds/sections/select-application?fund_id={test_round.fund_id}",
-        data={"round_id": str(test_round.round_id)},
-        follow_redirects=False,
-    )
+    response = submit_form(flask_test_client, url, {"round_id": str(test_round.round_id)}, follow_redirects=False)
     assert response.status_code == 302
 
     # Confirm redirect to application_bp.build_application

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -37,7 +37,7 @@ def get_csrf_token(response):
     return response.data.decode().split('name="csrf_token" type="hidden" value="')[1].split('"')[0]
 
 
-def submit_form(flask_test_client, url, data):
+def submit_form(flask_test_client, url, data, follow_redirects=True):
     """
     Submits a form given a flask test client, url, and the form data.
 
@@ -45,6 +45,7 @@ def submit_form(flask_test_client, url, data):
         flask_test_client: The flask test client to use.
         url: The url of the form to submit.
         data: The data to submit on the form.
+        follow_redirects: Whether to follow redirects after form submission.
 
     Returns:
         The response from submitting the form.
@@ -53,5 +54,5 @@ def submit_form(flask_test_client, url, data):
     csrf_token = get_csrf_token(response)
     data["csrf_token"] = csrf_token
     return flask_test_client.post(
-        url, data=data, follow_redirects=True, headers={"Content-Type": "application/x-www-form-urlencoded"}
+        url, data=data, follow_redirects=follow_redirects, headers={"Content-Type": "application/x-www-form-urlencoded"}
     )


### PR DESCRIPTION
### Ticket

https://mhclgdigital.atlassian.net/browse/FS-4927

### Understanding changes

This change is to render standard GOV.UK error UI components on the intermediary "Select fund" and "Select application" pages in the event of errored input, instead of the current default notification from front-end required validation. To do this, we need to render and validate actual Flask WTF forms.

### UI screenshot

![image](https://github.com/user-attachments/assets/dfcc4032-b6f8-405e-9294-7f8e2cc96749)
