### PR TITLE
FS:4935: Grant details template and API

### DIFF
--- a/app/blueprints/fund/routes.py
+++ b/app/blueprints/fund/routes.py
@@ -43,6 +43,50 @@ def view_fund():
     return render_template("fund_config.html", **params)
 
 
+@fund_bp.route("/details", methods=["GET"])
+def view_grant_details():
+    """
+    Renders grant details page
+    """
+    fund_id = request.args.get("grant_id")
+    fund = get_fund_by_id(fund_id)
+    fields = [
+        {"key": "Grant name", "value": fund.name_json["en"], "visuallyHiddenText": "name"},
+        {"key": "Grant title", "value": fund.title_json["en"], "visuallyHiddenText": "title"},
+        {"key": "Short name", "value": fund.short_name, "visuallyHiddenText": "short name"},
+        {
+            "key": "Funding type",
+            "value": fund.funding_type.get_text_for_display(),
+            "visuallyHiddenText": "funding type",
+        },
+        {"key": "Welsh available", "value": fund.welsh_available, "visuallyHiddenText": "Welsh available"},
+        {"key": "Description", "value": fund.description_json["en"], "visuallyHiddenText": "description"},
+        {
+            "key": "GGIS scheme reference number",
+            "value": fund.ggis_scheme_reference_number,
+            "visuallyHiddenText": "GGIS scheme reference number",
+        },
+    ]
+
+    summary_data = [
+        {
+            "key": {"text": field["key"]},
+            "value": {"text": field["value"]},
+            "actions": {
+                "items": [
+                    {
+                        "href": url_for("fund_bp.edit_fund", fund_id=fund.fund_id),
+                        "text": "Change",
+                        "visuallyHiddenText": field["visuallyHiddenText"],
+                    }
+                ]
+            },
+        }
+        for field in fields
+    ]
+    return render_template("grant_details.html", fund=fund, summary_data=summary_data)
+
+
 @fund_bp.route("/create", methods=["GET", "POST"])
 def create_fund():
     """Creates a new fund"""

--- a/app/blueprints/fund/templates/grant_details.html
+++ b/app/blueprints/fund/templates/grant_details.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{%- from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList -%}
+{% block content %}
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        {{ govukBackLink({
+          "text": "Back",
+          "href": "#"
+        }) }}
+        <h2 class="govuk-heading-m">{{ fund.name_json["en"] }}</h2>
+        {{ govukSummaryList({
+            "classes": "govuk-!-margin-bottom-9",
+                "rows": summary_data
+        }) }}
+    </div>
+</div>
+{% endblock content %}

--- a/app/export_config/generate_fund_round_form_jsons.py
+++ b/app/export_config/generate_fund_round_form_jsons.py
@@ -99,4 +99,7 @@ def generate_form_jsons_for_round(round_id, base_output_dir=None):
             if valid_json:
                 write_config(form_json, form.runner_publish_name, round.short_name, "form_json", base_output_dir)
             else:
-                current_app.logger.error("Form JSON for {runner_publish_name} is invalid.", extra=dict(runner_publish_name=form.runner_publish_name))
+                current_app.logger.error(
+                    "Form JSON for {runner_publish_name} is invalid.",
+                    extra=dict(runner_publish_name=form.runner_publish_name),
+                )

--- a/tests/blueprints/fund/test_routes.py
+++ b/tests/blueprints/fund/test_routes.py
@@ -76,6 +76,28 @@ def test_create_fund_with_existing_short_name(flask_test_client):
 
 
 @pytest.mark.usefixtures("set_auth_cookie", "patch_validate_token_rs256_internal_user")
+def test_view_grant_details(flask_test_client, seed_dynamic_data):
+    """
+    Test to check grant detail route is working as expected.
+    and verify the grant details template is rendered as expected.
+    """
+    invalid_fund_id = "123e4567-e89b-12d3-a456-426614174000"
+    with pytest.raises(ValueError, match=f"Fund with id {invalid_fund_id} not found"):
+        flask_test_client.get(f"/funds/details?grant_id={invalid_fund_id}", follow_redirects=True)
+
+    test_fund = seed_dynamic_data["funds"][0]
+    response = flask_test_client.get(f"/funds/details?grant_id={test_fund.fund_id}", follow_redirects=True)
+    assert response.status_code == 200
+    html = response.data.decode("utf-8")
+
+    assert f'<h2 class="govuk-heading-m">{test_fund.name_json["en"]}</h2>' in html
+    assert (
+        f'<a class="govuk-link" href="/funds/{test_fund.fund_id}">Change<span class="govuk-visually-hidden"> name</span></a>'  # noqa: E501
+        in html
+    )
+
+
+@pytest.mark.usefixtures("set_auth_cookie", "patch_validate_token_rs256_internal_user")
 def test_update_fund(flask_test_client, seed_dynamic_data):
     """
     Tests that a fund can be successfully updated using the /funds/<fund_id> route


### PR DESCRIPTION
Ticket: https://mhclgdigital.atlassian.net/browse/FS-4935


### Change description
1. In this Ticket grant_details API is added to render the fund/grant created.

- [ x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
1. Use FAB
3. Create a fund
4. Try render the fund using url ex:
 <FAB_URL>/funds/details?grant_id=<fund_id>
ex: https://fund-application-builder.levellingup.gov.localhost:3011/funds/details?grant_id=f9aa36e3-d42e-4416-9113-bd47dbd0a6f3

<img width="1210" alt="image" src="https://github.com/user-attachments/assets/5c87145c-9459-4a82-a7b8-f0a4404bf65b" />

