### PR TITLE
FS:4590- Implement Signout for FAB

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -15,7 +15,12 @@
     "useTudorCrown": "yes",
     "serviceName": "Fund Application Builder",
     "serviceUrl": url_for("index_bp.index"),
-    "classes": "govuk-header--full-width-border"
+    "navigation": [
+        {
+            "text": "Sign out",
+            "href": g.logout_url
+        }
+    ]  if g.is_authenticated else []
   }) }}
 
   {# Only show the custom navigation if showNavigationBar is set #}

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -14,7 +14,9 @@ class DefaultConfig(object):
     FLASK_ENV = CommonConfig.FLASK_ENV
     SECRET_KEY = CommonConfig.SECRET_KEY
 
-    FAB_HOST = getenv("FAB_HOST", "fab:8080/")
+    FUND_APPLICATION_BUILDER_HOST = getenv(
+        "FUND_APPLICATION_BUILDER_HOST", "https://fund-application-builder.levellingup.gov.localhost:3011"
+    )
     FAB_SAVE_PER_PAGE = getenv("FAB_SAVE_PER_PAGE", "dev/save")
     FORM_RUNNER_URL = getenv("FORM_RUNNER_INTERNAL_HOST", "http://form-runner:3009")
     FORM_RUNNER_URL_REDIRECT = getenv("FORM_RUNNER_EXTERNAL_HOST", "http://localhost:3009")
@@ -25,7 +27,7 @@ class DefaultConfig(object):
 
     FSD_USER_TOKEN_COOKIE_NAME = "fsd_user_token"
     AUTHENTICATOR_HOST = getenv("AUTHENTICATOR_HOST", "https://authenticator.levellingup.gov.localhost:4004")
-
+    LOGOUT_URL_OVERRIDE = f"{AUTHENTICATOR_HOST}/sessions/sign-out?return_app=fund-application-builder&return_path=/"  # noqa: E501
     # RSA 256 Keys
     RSA256_PUBLIC_KEY_BASE64 = getenv("RSA256_PUBLIC_KEY_BASE64")
     if RSA256_PUBLIC_KEY_BASE64:

--- a/copilot/fsd-fund-application-builder/manifest.yml
+++ b/copilot/fsd-fund-application-builder/manifest.yml
@@ -44,7 +44,7 @@ network:
 #
 # Pass environment variables as key value pairs.
 variables:
-  APPLICANT_fund-application-builder_HOST: "https://fund-application-builder.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
+  FUND_APPLICATION_BUILDER_HOST: "https://fund-application-builder.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
   AUTHENTICATOR_HOST: "https://authenticator.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
   COOKIE_DOMAIN: ".test.levellingup.gov.uk"
   FLASK_ENV: ${COPILOT_ENVIRONMENT_NAME}


### PR DESCRIPTION
Ticket : https://mhclgdigital.atlassian.net/browse/FS-4950

### Change description
Add Sign out functionality for FAB.
1. Internal users authenticated can now signout using Sign out link available in header.
2. Sign out is available in all pages with in FAB from Header only After user is logged in


- [x ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
1. Use FAB
2. Login to FAB 
3. Sign out link is available for the user to logout
4. Once the user clicks on  Sign out , user is logged out and  redirect to Authenticator login page, on login it redirects to FAB Dashboard/Home page


<img width="1355" alt="image" src="https://github.com/user-attachments/assets/76150722-5e9e-4207-8a74-a440be49206a" />
<img width="1381" alt="image" src="https://github.com/user-attachments/assets/8bb1c71b-7769-43b3-892f-9134d1b7cefb" />

