### PR TITLE
FS-4935: Grant details template and API 

### DIFF
--- a/app/blueprints/fund/routes.py
+++ b/app/blueprints/fund/routes.py
@@ -64,6 +64,16 @@ def view_fund():
     return render_template("fund_config.html", **params)
 
 
+@fund_bp.route("/<uuid:fund_id>", methods=["GET"])
+def view_fund_details(fund_id):
+    """
+    Renders grant details page
+    """
+    form = FundForm()
+    fund = get_fund_by_id(fund_id)
+    return render_template("fund_details.html", form=form, fund=fund)
+
+
 @fund_bp.route("/create", methods=["GET", "POST"])
 def create_fund():
     """Creates a new fund"""
@@ -103,7 +113,7 @@ def create_fund():
     return render_template("fund.html", form=form, fund_id=None, error=error)
 
 
-@fund_bp.route("/<fund_id>", methods=["GET", "POST"])
+@fund_bp.route("/<uuid:fund_id>/edit", methods=["GET", "POST"])
 def edit_fund(fund_id):
     """Updates an existing fund"""
     fund = get_fund_by_id(fund_id)
@@ -146,7 +156,7 @@ def edit_fund(fund_id):
         update_fund(fund)
         if request.form.get("action") == "return_home":
             return redirect(url_for(INDEX_BP_DASHBOARD))
-        return redirect(url_for("fund_bp.view_fund", fund_id=fund.fund_id))
+        return redirect(url_for("fund_bp.view_fund_details", fund_id=fund.fund_id))
 
     error = error_formatter(form)
     return render_template("fund.html", form=form, fund_id=fund_id, error=error)

--- a/app/blueprints/fund/services.py
+++ b/app/blueprints/fund/services.py
@@ -1,3 +1,5 @@
+from flask import url_for
+
 from app.db.models import Fund
 
 
@@ -5,7 +7,11 @@ def build_fund_rows(funds: list[Fund]) -> list[dict]:
     rows = []
     for fund in funds:
         row = [
-            {"html": f"""<a class='govuk-link--no-visited-state'href='#'>{fund.name_json['en']}</a>"""},
+            {
+                # TODO move this html to template and use namespace functionality
+                "html": f"""<a class='govuk-link--no-visited-state'
+                href={url_for("fund_bp.view_fund_details", fund_id=fund.fund_id)}>{fund.name_json["en"]}</a>"""
+            },  # noqa: E501
             {"text": fund.description_json["en"]},
             {"text": fund.funding_type.get_text_for_display()},
         ]

--- a/app/blueprints/fund/templates/fund_details.html
+++ b/app/blueprints/fund/templates/fund_details.html
@@ -1,0 +1,161 @@
+{% extends "base.html" %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{%- from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList -%}
+{% set showNavigationBar = True %}
+{% set active_item_identifier = "grants" %}
+{% block content %}
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        {{ govukBackLink({
+          "text": "Back",
+          "href": url_for("fund_bp.view_all_funds")
+        }) }}
+        <h2 class="govuk-heading-l">{{ fund.name_json["en"] }}</h2>
+        {{ govukSummaryList({
+            "classes": "govuk-!-margin-bottom-9",
+                "rows": [
+                    {
+                        "key": {"text": "Grant name"},
+                        "value": {"text": fund.name_json["en"]},
+                        "actions": {
+                            "items": [
+                                {
+                                    "href": url_for(endpoint="fund_bp.edit_fund", fund_id=fund.fund_id, _anchor=form.name_en.id),
+                                    "text": "Change",
+                                    "classes": "govuk-link--no-visited-state",
+                                    "visuallyHiddenText": "Name english",
+                                }
+                            ]
+                        },
+                    },
+                    {
+                        "key": {"text": "Grant name (Welsh)"},
+                        "value": {"text": fund.name_json["cy"]},
+                        "actions": {
+                            "items": [
+                                {
+                                    "href": url_for(endpoint="fund_bp.edit_fund", fund_id=fund.fund_id, _anchor=form.name_cy.id),
+                                    "text": "Change",
+                                    "classes": "govuk-link--no-visited-state",
+                                    "visuallyHiddenText": "Name welsh",
+                                }
+                            ]
+                        },
+                    } if fund.welsh_available else {},
+                    {
+                        "key": {"text": "Short name"},
+                        "value": {"text": fund.short_name},
+                        "actions": {
+                            "items": [
+                                {
+                                    "href": url_for(endpoint="fund_bp.edit_fund", fund_id=fund.fund_id, _anchor=form.short_name.id),
+                                    "text": "Change",
+                                    "classes": "govuk-link--no-visited-state",
+                                    "visuallyHiddenText": "short name",
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "key": {"text": "Application heading"},
+                        "value": {"text": "Apply for " + fund.title_json["en"]},
+                        "actions": {
+                            "items": [
+                                {
+                                    "href": url_for(endpoint="fund_bp.edit_fund", fund_id=fund.fund_id, _anchor=form.title_en.id),
+                                    "text": "Change",
+                                    "classes": "govuk-link--no-visited-state",
+                                    "visuallyHiddenText": "title english",
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "key": {"text": "Application heading (Welsh)"},
+                        "value": {"text": "Apply for " + fund.title_json["cy"] if fund.title_json["cy"] else ""},
+                        "actions": {
+                            "items": [
+                                {
+                                    "href": url_for(endpoint="fund_bp.edit_fund", fund_id=fund.fund_id, _anchor=form.title_cy.id),
+                                    "text": "Change",
+                                    "classes": "govuk-link--no-visited-state",
+                                    "visuallyHiddenText": "title welsh",
+                                }
+                            ]
+                        },
+                    } if fund.welsh_available else {},
+                    {
+                        "key": {"text": "Funding type"},
+                        "value": {"text": fund.funding_type.get_text_for_display()},
+                        "actions": {
+                            "items": [
+                                {
+                                    "href": url_for(endpoint="fund_bp.edit_fund", fund_id=fund.fund_id, _anchor=form.funding_type.id),
+                                    "text": "Change",
+                                    "classes": "govuk-link--no-visited-state",
+                                    "visuallyHiddenText": "funding type",
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "key": {"text": "Welsh available"},
+                        "value": {"text": "Yes" if fund.welsh_available else "No"},
+                        "actions": {
+                            "items": [
+                                {
+                                    "href": url_for(endpoint="fund_bp.edit_fund", fund_id=fund.fund_id, _anchor=form.welsh_available.id),
+                                    "text": "Change",
+                                    "classes": "govuk-link--no-visited-state",
+                                    "visuallyHiddenText": "welsh available",
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "key": {"text": "Description"},
+                        "value": {"text": fund.description_json["en"]},
+                        "actions": {
+                            "items": [
+                                {
+                                    "href": url_for(endpoint="fund_bp.edit_fund", fund_id=fund.fund_id, _anchor=form.description_en.id),
+                                    "text": "Change",
+                                    "classes": "govuk-link--no-visited-state",
+                                    "visuallyHiddenText": "description english",
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "key": {"text": "Description (Welsh)"},
+                        "value": {"text": fund.description_json["cy"]},
+                        "actions": {
+                            "items": [
+                                {
+                                    "href": url_for(endpoint="fund_bp.edit_fund", fund_id=fund.fund_id, _anchor=form.description_cy.id),
+                                    "text": "Change",
+                                    "classes": "govuk-link--no-visited-state",
+                                    "visuallyHiddenText": "description welsh",
+                                }
+                            ]
+                        }
+                    } if fund.welsh_available else {},
+                    {
+                        "key": {"text": "GGIS scheme reference number"},
+                        "value": {"text": fund.ggis_scheme_reference_number},
+                        "actions": {
+                            "items": [
+                                {
+                                    "href": url_for(endpoint="fund_bp.edit_fund", fund_id=fund.fund_id, _anchor=form.ggis_scheme_reference_number.id),
+                                    "text": "Change",
+                                    "classes": "govuk-link--no-visited-state",
+                                    "visuallyHiddenText": "GGIS scheme reference number",
+                                }
+                            ]
+                        }
+                    },
+                ]
+        }) }}
+    </div>
+</div>
+{% endblock content %}


### PR DESCRIPTION
Ticket: https://mhclgdigital.atlassian.net/browse/FS-4935


### Change description
In this Ticket grant_details API is added to render the grant details when clicked on grant name in Grants list page.

- [x ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
1. Use FAB
2. Create a fund/grant
3. Click on Grants menu to list all grants.
4. Click on one of the Grant name , This will render a grant detail page.
ex: https://fund-application-builder.levellingup.gov.localhost:3011/grants/details?grant_id=f9aa36e3-d42e-4416-9113-bd47dbd0a6f3
5. Clicking on Back button should redirect to Grants list page.
6. Clicking on change link for the field will redirect to  edit grant/fund page with focus on the field selected for change
7. Clicking on "Continue and Save" will redirect to grant details page

### Screenshots of UI changes (if applicable)

<img width="1131" alt="image" src="https://github.com/user-attachments/assets/b1913e66-9a8e-45be-b109-89052d653e68" />
<img width="1190" alt="image" src="https://github.com/user-attachments/assets/c8a70c4a-57a4-40b1-a6fb-77c40db37cd1" />
<img width="1026" alt="image" src="https://github.com/user-attachments/assets/dd86f7e7-de83-409d-a901-9541a4fbf1d8" />



