### PR TITLE
Bugfix - rendering HTML in notification banner properly

### DIFF
--- a/app/blueprints/index/templates/dashboard.html
+++ b/app/blueprints/index/templates/dashboard.html
@@ -7,15 +7,9 @@
     <div class="govuk-width-container">
         {% with messages = get_flashed_messages() %}
             {% if messages %}
-                {% set html %}
-                    <p class="govuk-notification-banner__body">{{ messages[0] }}</p>
-                {% endset %}
-                {{
-                    govukNotificationBanner({
-                        "html": html,
-                        "type": "success"
-                    })
-                }}
+                <div class="govuk-grid-row">
+                    {{ govukNotificationBanner({"html": messages[0], "type": "success"}) }}
+                </div>
             {% endif %}
         {% endwith %}
         <div class="govuk-grid-row">


### PR DESCRIPTION
Fix for the issue pointed out by @tejvath on this ticket: https://mhclgdigital.atlassian.net/browse/FS-4925

Basically we weren't rendering HTML in the notification banner on the dashboard properly.

We can test this by creating a new fund, clicking "Save and return to home", and checking that the HTML content in the notification banner at the top of the dashboard is rendered as HTML, not text.