### PR TITLE
Fix GOV.UK Service navigation implementation

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -13,6 +13,7 @@
 {% block header %}
   {{ govukHeader({
     "useTudorCrown": "yes",
+    "classes": "govuk-header--full-width-border",
     "serviceName": "Fund Application Builder",
     "serviceUrl": url_for("index_bp.index"),
     "navigation": [


### PR DESCRIPTION
Guidance for this component says that when it's used beneath a GOV.UK Header, we need to set the header border (the blue bar) to be full width.

https://design-system.service.gov.uk/components/service-navigation/

## Before
![fund-application-builder levellingup gov localhost_3011_templates (1)](https://github.com/user-attachments/assets/b8a21a0c-5c53-4239-8bbd-289a55b9f77a)


## After
![fund-application-builder levellingup gov localhost_3011_templates](https://github.com/user-attachments/assets/414a1db4-9eb8-47c2-85df-2588d9d9ff0e)
