### PR TITLE
FS-4963: Refactor generic table page macro

### DIFF
--- a/app/blueprints/fund/routes.py
+++ b/app/blueprints/fund/routes.py
@@ -32,12 +32,6 @@ def view_all_funds():
     Renders list of grants in the grant page
     """
     params = GenericTablePage(
-        page_heading="Grants",
-        page_description="View all existing grants or add a new grant.",
-        detail_text="Creating new grants",
-        detail_description="This is an placeholder which will be added for the grants page",
-        button_text="Add new grant",
-        button_url=url_for("fund_bp.create_fund", action="grants_table"),
         table_header=[{"text": "Grant Name"}, {"text": "Description"}, {"text": "Grant Type"}],
         table_rows=build_fund_rows(get_all_funds()),
         current_page=int(request.args.get("page", 1)),

--- a/app/blueprints/fund/routes.py
+++ b/app/blueprints/fund/routes.py
@@ -12,8 +12,8 @@ from app.blueprints.fund.forms import FundForm
 from app.blueprints.fund.services import build_fund_rows
 from app.db.models.fund import Fund, FundingType
 from app.db.queries.fund import add_fund, get_all_funds, get_fund_by_id, update_fund
-from app.shared.generic_table_page import GenericTablePage
 from app.shared.helpers import all_funds_as_govuk_select_items, error_formatter, flash_message
+from app.shared.table_pagination import GovUKTableAndPagination
 
 INDEX_BP_DASHBOARD = "index_bp.dashboard"
 
@@ -31,7 +31,7 @@ def view_all_funds():
     """
     Renders list of grants in the grant page
     """
-    params = GenericTablePage(
+    params = GovUKTableAndPagination(
         table_header=[{"text": "Grant Name"}, {"text": "Description"}, {"text": "Grant Type"}],
         table_rows=build_fund_rows(get_all_funds()),
         current_page=int(request.args.get("page", 1)),

--- a/app/blueprints/fund/templates/view_all_funds.html
+++ b/app/blueprints/fund/templates/view_all_funds.html
@@ -3,7 +3,7 @@
 {% set showNavigationBar = True %}
 {% set active_item_identifier = "grants" %}
 
-{%- from "macros/genericTablePage.html" import govukGenericTableTemplate -%}
+{%- from "macros/tablePagination.html" import govukTablePagination -%}
 {% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
 {%- from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary -%}
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
@@ -33,7 +33,7 @@
             }) }}
         </div>
     </div>
-    {{ govukGenericTableTemplate({
-        "generic_table_page": generic_table_page
+    {{ govukTablePagination({
+        "table_pagination_page": table_pagination_page
     }) }}
 {% endblock content %}

--- a/app/blueprints/fund/templates/view_all_funds.html
+++ b/app/blueprints/fund/templates/view_all_funds.html
@@ -4,8 +4,35 @@
 {% set active_item_identifier = "grants" %}
 
 {%- from "macros/genericTablePage.html" import govukGenericTableTemplate -%}
+{% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
+{%- from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary -%}
+{%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
+
 
 {% block content %}
+    {% with messages = get_flashed_messages() %}
+        {% if messages %}
+            <div class="govuk-grid-row">
+                {{ govukNotificationBanner({"html": messages[0],"type": "success"}) }}
+            </div>
+        {% endif %}
+    {% endwith %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-l">Grants</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-three-quarters">
+            <p class="govuk-body">View all existing grants or add a new grant.</p>
+        </div>
+        <div class="govuk-grid-column-one-quarter govuk-!-text-align-right">
+            {{ govukButton({
+                "text": "Add new grant",
+                "href": url_for("fund_bp.create_fund", action="grants_table")
+            }) }}
+        </div>
+    </div>
     {{ govukGenericTableTemplate({
         "generic_table_page": generic_table_page
     }) }}

--- a/app/blueprints/round/routes.py
+++ b/app/blueprints/round/routes.py
@@ -39,12 +39,6 @@ def view_all_rounds():
     Renders a list of rounds in the application page
     """
     params = GenericTablePage(
-        page_heading="Applications",
-        page_description="View existing applications or create a new one.",
-        detail_text="Creating a new grant application",
-        detail_description="Follow the step-by-step instructions to create a new grant application.",
-        button_text="Create new application",
-        button_url=url_for("round_bp.select_fund", action="applications_table"),
         table_header=[{"text": "Application name"}, {"text": "Grant"}, {"text": ""}],
         table_rows=build_round_rows(get_all_rounds()),
         current_page=int(request.args.get("page", 1)),

--- a/app/blueprints/round/routes.py
+++ b/app/blueprints/round/routes.py
@@ -20,8 +20,8 @@ from app.db.queries.clone import clone_single_round
 from app.db.queries.fund import get_all_funds, get_fund_by_id
 from app.db.queries.round import get_all_rounds, get_round_by_id
 from app.shared.forms import SelectFundForm
-from app.shared.generic_table_page import GenericTablePage
 from app.shared.helpers import error_formatter, flash_message
+from app.shared.table_pagination import GovUKTableAndPagination
 
 INDEX_BP_DASHBOARD = "index_bp.dashboard"
 
@@ -38,7 +38,7 @@ def view_all_rounds():
     """
     Renders a list of rounds in the application page
     """
-    params = GenericTablePage(
+    params = GovUKTableAndPagination(
         table_header=[{"text": "Application name"}, {"text": "Grant"}, {"text": ""}],
         table_rows=build_round_rows(get_all_rounds()),
         current_page=int(request.args.get("page", 1)),

--- a/app/blueprints/round/templates/view_all_rounds.html
+++ b/app/blueprints/round/templates/view_all_rounds.html
@@ -4,8 +4,35 @@
 {% set active_item_identifier = "applications" %}
 
 {%- from "macros/genericTablePage.html" import govukGenericTableTemplate -%}
+{% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
+{%- from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary -%}
+{%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
+
 
 {% block content %}
+    {% with messages = get_flashed_messages() %}
+        {% if messages %}
+            <div class="govuk-grid-row">
+                {{ govukNotificationBanner({"html": messages[0],"type": "success"}) }}
+            </div>
+        {% endif %}
+    {% endwith %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-l">Applications</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-three-quarters">
+            <p class="govuk-body">View existing applications or create a new one.</p>
+        </div>
+        <div class="govuk-grid-column-one-quarter govuk-!-text-align-right">
+            {{ govukButton({
+                "text": "Create new application",
+                "href": url_for("round_bp.select_fund", action="applications_table")
+            }) }}
+        </div>
+    </div>
     {{ govukGenericTableTemplate({
         "generic_table_page": generic_table_page
     }) }}

--- a/app/blueprints/round/templates/view_all_rounds.html
+++ b/app/blueprints/round/templates/view_all_rounds.html
@@ -3,7 +3,7 @@
 {% set showNavigationBar = True %}
 {% set active_item_identifier = "applications" %}
 
-{%- from "macros/genericTablePage.html" import govukGenericTableTemplate -%}
+{%- from "macros/tablePagination.html" import govukTablePagination -%}
 {% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
 {%- from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary -%}
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
@@ -33,7 +33,7 @@
             }) }}
         </div>
     </div>
-    {{ govukGenericTableTemplate({
-        "generic_table_page": generic_table_page
+    {{ govukTablePagination({
+        "table_pagination_page": table_pagination_page
     }) }}
 {% endblock content %}

--- a/app/blueprints/template/routes.py
+++ b/app/blueprints/template/routes.py
@@ -13,8 +13,8 @@ from app.db.queries.application import (
     get_form_by_template_name,
     update_form,
 )
-from app.shared.generic_table_page import GenericTablePage
 from app.shared.helpers import error_formatter
+from app.shared.table_pagination import GovUKTableAndPagination
 
 template_bp = Blueprint(
     "template_bp",
@@ -32,7 +32,7 @@ def view_templates():
     form_designer_url = current_app.config["FORM_DESIGNER_URL_REDIRECT"] + "/app"
     params = {"sections": sections, "forms": forms, "uploadform": form}
     params.update(
-        GenericTablePage(
+        GovUKTableAndPagination(
             table_header=[
                 {"text": "Template name"},
                 {"text": "Task name"},

--- a/app/blueprints/template/routes.py
+++ b/app/blueprints/template/routes.py
@@ -1,6 +1,6 @@
 import json
 
-from flask import Blueprint, redirect, render_template, request, url_for
+from flask import Blueprint, current_app, redirect, render_template, request, url_for
 from werkzeug.utils import secure_filename
 
 from app.blueprints.template.forms import TemplateFormForm, TemplateUploadForm
@@ -15,7 +15,6 @@ from app.db.queries.application import (
 )
 from app.shared.generic_table_page import GenericTablePage
 from app.shared.helpers import error_formatter
-from config import Config
 
 template_bp = Blueprint(
     "template_bp",
@@ -30,18 +29,10 @@ def view_templates():
     sections = get_all_template_sections()
     forms = get_all_template_forms()
     form = TemplateUploadForm()
+    form_designer_url = current_app.config["FORM_DESIGNER_URL_REDIRECT"] + "/app"
     params = {"sections": sections, "forms": forms, "uploadform": form}
     params.update(
         GenericTablePage(
-            page_heading="Templates",
-            page_description_html=render_template(
-                "partials/view_template_page_description.html",
-                form_designer_href=f"{Config.FORM_DESIGNER_URL_REDIRECT}/app",
-            ),
-            detail_text="Creating new templates",
-            detail_description_html=render_template("partials/view_templates_details_description.html"),
-            button_text="Upload template",
-            button_url="#",
             table_header=[
                 {"text": "Template name"},
                 {"text": "Task name"},
@@ -57,7 +48,11 @@ def view_templates():
         file = form.file.data
         if get_form_by_template_name(template_name):
             form.error = "Template name already exists"
-            return render_template("view_templates.html", **params)
+            return render_template(
+                "view_templates.html",
+                **params,
+                form_designer_url=form_designer_url,
+            )
 
         if file:
             try:
@@ -68,14 +63,18 @@ def view_templates():
             except Exception as e:
                 print(e)
                 form.error = "Invalid file: Please upload valid JSON file"
-                return render_template("view_templates.html", **params)
+                return render_template(
+                    "view_templates.html",
+                    **params,
+                    form_designer_url=form_designer_url,
+                )
 
         return redirect(url_for("template_bp.view_templates"))
 
     error = None
     if "uploadform" in params:
         error = error_formatter(params["uploadform"])
-    return render_template("view_templates.html", **params, error=error)
+    return render_template("view_templates.html", **params, error=error, form_designer_url=form_designer_url)
 
 
 @template_bp.route("/<form_id>", methods=["GET", "POST"])

--- a/app/blueprints/template/templates/partials/view_template_page_description.html
+++ b/app/blueprints/template/templates/partials/view_template_page_description.html
@@ -1,7 +1,0 @@
-<p class="govuk-body">
-    View existing templates or upload a new template you have created using
-    <br>
-    <a class="govuk-link"
-       target="_blank"
-       href="{{ form_designer_href }}">Form Designer (opens in a new tab)</a>.
-</p>

--- a/app/blueprints/template/templates/partials/view_templates_details_description.html
+++ b/app/blueprints/template/templates/partials/view_templates_details_description.html
@@ -1,8 +1,0 @@
-<p>You should use existing templates for standard application questions. For example, all
-    grant applications should collect organisation and risk information in the same way.</p>
-<p>If your application needs questions specific to the grant, you can create a new template by:</p>
-<ol>
-    <li>designing the template in Form Designer</li>
-    <li>downloading the template</li>
-    <li>uploading the template to Fund application builder</li>
-</ol>

--- a/app/blueprints/template/templates/view_templates.html
+++ b/app/blueprints/template/templates/view_templates.html
@@ -4,12 +4,61 @@
 
 {% from "macros/wtfToGovUk.html" import input %}
 {%- from "govuk_frontend_jinja/components/file-upload/macro.html" import govukFileUpload -%}
-{%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
-{% from "govuk_frontend_jinja/components/table/macro.html" import govukTable %}
-{%- from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary -%}
 {%- from "macros/genericTablePage.html" import govukGenericTableTemplate -%}
+{% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
+{%- from "govuk_frontend_jinja/components/details/macro.html" import govukDetails -%}
+{%- from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary -%}
+{%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
+
 
 {% block content %}
+    {% with messages = get_flashed_messages() %}
+        {% if messages %}
+            <div class="govuk-grid-row">
+                {{ govukNotificationBanner({"html": messages[0],"type": "success"}) }}
+            </div>
+        {% endif %}
+    {% endwith %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-l">Templates</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-three-quarters">
+            <p class="govuk-body">
+                View existing templates or upload a new template you have created using
+                <br>
+                <a class="govuk-link"
+                   target="_blank"
+                   href="{{ config.FORM_DESIGNER_URL_REDIRECT }}/app">Form Designer (opens in a new tab)</a>.
+            </p>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        {% set detailsHTML %}
+            <p class="govuk-body">You should use existing templates for standard application questions. For example, all
+                grant applications should collect organisation and risk information in the same way.</p>
+            <p class="govuk-body">If your application needs questions specific to the grant, you can create a new template by:</p>
+            <ol>
+                <li>designing the template in Form Designer</li>
+                <li>downloading the template</li>
+                <li>uploading the template to Fund application builder</li>
+            </ol>
+        {% endset %}
+        <div class="govuk-grid-column-three-quarters">
+            {{ govukDetails({
+                "summaryText": "Creating new templates",
+                "html": detailsHTML
+            }) }}
+        </div>
+        <div class="govuk-grid-column-one-quarter govuk-!-text-align-right">
+            {{ govukButton({
+                "text": "Upload template",
+                "href": "#"
+            }) }}
+        </div>
+    </div>
     {{ govukGenericTableTemplate({
         "generic_table_page": generic_table_page
     }) }}

--- a/app/blueprints/template/templates/view_templates.html
+++ b/app/blueprints/template/templates/view_templates.html
@@ -31,7 +31,7 @@
                 <br>
                 <a class="govuk-link"
                    target="_blank"
-                   href="{{ config.FORM_DESIGNER_URL_REDIRECT }}/app">Form Designer (opens in a new tab)</a>.
+                   href="{{ form_designer_url }}">Form Designer (opens in a new tab)</a>.
             </p>
         </div>
     </div>

--- a/app/blueprints/template/templates/view_templates.html
+++ b/app/blueprints/template/templates/view_templates.html
@@ -4,7 +4,7 @@
 
 {% from "macros/wtfToGovUk.html" import input %}
 {%- from "govuk_frontend_jinja/components/file-upload/macro.html" import govukFileUpload -%}
-{%- from "macros/genericTablePage.html" import govukGenericTableTemplate -%}
+{%- from "macros/tablePagination.html" import govukTablePagination -%}
 {% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
 {%- from "govuk_frontend_jinja/components/details/macro.html" import govukDetails -%}
 {%- from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary -%}
@@ -59,8 +59,8 @@
             }) }}
         </div>
     </div>
-    {{ govukGenericTableTemplate({
-        "generic_table_page": generic_table_page
+    {{ govukTablePagination({
+        "table_pagination_page": table_pagination_page
     }) }}
 
 {% endblock %}

--- a/app/shared/generic_table_page.py
+++ b/app/shared/generic_table_page.py
@@ -4,29 +4,15 @@ import math
 class GenericTablePage:
     def __init__(
         self,
-        page_heading: str,
-        detail_text: str,
-        button_text: str,
-        button_url: str,
         table_header: list[dict],
         table_rows: list[dict],
         current_page: int = 1,
         rows_per_page: int = 20,
-        page_description: str = None,
-        page_description_html: str = None,
-        detail_description: str = None,
-        detail_description_html: str = None,
     ):
         """
         Initializes the GenericTablePage object with the necessary metadata for rendering a generic table page.
 
         Args:
-            page_heading (str): The heading for the page.
-            page_description (str): The description to display on the page.
-            detail_text (str): A detail title or introductory text for the page.
-            detail_description (str): A detail description of the detail title.
-            button_text (str): The text for a button on the page.
-            button_url (str): Button URL for the page.
             table_header (list): The heading of the table, typically the column headers.
             table_rows (list): A list of table rows to be displayed on the page.
             current_page (int): When using pagination, this variable will be used to determine the page. Default to 1.
@@ -34,24 +20,6 @@ class GenericTablePage:
         """
         pagination, paginated_rows = self.pagination(table_rows, current_page, rows_per_page)
         self.generic_table_page = {
-            "page_heading": page_heading,
-            **(
-                {"page_description": page_description}
-                if page_description
-                else {"page_description_html": page_description_html}
-            ),
-            "detail": {
-                "detail_text": detail_text,
-                **(
-                    {"detail_description": detail_description}
-                    if detail_description
-                    else {"detail_description_html": detail_description_html}
-                ),
-            },
-            "button": {
-                "button_text": button_text,
-                "button_url": button_url,
-            },
             "table": {"table_header": table_header, "table_rows": paginated_rows},
             **({"pagination": pagination} if bool(pagination) else {}),
         }

--- a/app/shared/table_pagination.py
+++ b/app/shared/table_pagination.py
@@ -1,7 +1,7 @@
 import math
 
 
-class GenericTablePage:
+class GovUKTableAndPagination:
     def __init__(
         self,
         table_header: list[dict],
@@ -10,7 +10,8 @@ class GenericTablePage:
         rows_per_page: int = 20,
     ):
         """
-        Initializes the GenericTablePage object with the necessary metadata for rendering a generic table page.
+        Initializes the GovUKTableAndPagination object with the necessary metadata for rendering a generic GovUK table
+        with pagination.
 
         Args:
             table_header (list): The heading of the table, typically the column headers.
@@ -19,7 +20,7 @@ class GenericTablePage:
             rows_per_page (int): The number of rows to display per page. Default to 20.
         """
         pagination, paginated_rows = self.pagination(table_rows, current_page, rows_per_page)
-        self.generic_table_page = {
+        self.table_pagination_page = {
             "table": {"table_header": table_header, "table_rows": paginated_rows},
             **({"pagination": pagination} if bool(pagination) else {}),
         }

--- a/app/templates/macros/genericTablePage.html
+++ b/app/templates/macros/genericTablePage.html
@@ -1,64 +1,23 @@
 {% macro govukGenericTableTemplate(params) %}
 
-    {% from "govuk_frontend_jinja/macros/attributes.html" import govukAttributes -%}
-    {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
     {% from "govuk_frontend_jinja/components/table/macro.html" import govukTable %}
-    {%- from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary -%}
     {%- from "govuk_frontend_jinja/components/pagination/macro.html" import govukPagination -%}
-    {%- from "govuk_frontend_jinja/components/details/macro.html" import govukDetails -%}
-    {% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
 
-    {% with messages = get_flashed_messages() %}
-        {% if messages %}
-            <div class="govuk-grid-row">
-                {{ govukNotificationBanner({"html": messages[0],"type": "success"}) }}
-            </div>
-        {% endif %}
-    {% endwith %}
     <div class="govuk-grid-row">
-        <h1 class="govuk-heading-l">{{ params.generic_table_page.page_heading }}</h1>
-        {% if params.generic_table_page.page_description %}
-            <p class="govuk-body">{{ params.generic_table_page.page_description }}</p>
-        {% endif %}
-        {% if params.generic_table_page.page_description_html %}
-            {{ params.generic_table_page.page_description_html | safe }}
-        {% endif %}
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-three-quarters govuk-!-padding-0">
-            {% if params.generic_table_page.detail and params.generic_table_page.detail.detail_text %}
-                {% set description = params.generic_table_page.detail.detail_description or params.generic_table_page.detail.detail_description_html %}
-                {% set description_type = 'text' if params.generic_table_page.detail.detail_description else 'html' %}
-                {% if description %}
-                    {{ govukDetails({
-                        "summaryText": params.generic_table_page.detail.detail_text,
-                        description_type: description
-                    }) }}
-                {% endif %}
-            {% endif %}
-        </div>
-        <div class="govuk-grid-column-one-quarter govuk-!-padding-0 govuk-!-text-align-right">
-            {% if params.generic_table_page.button and params.generic_table_page.button.button_text and params.generic_table_page.button.button_text %}
-                {{ govukButton({
-                  "text": params.generic_table_page.button.button_text,
-                  "href": params.generic_table_page.button.button_url
-            }) }}
-            {% endif %}
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        {% if params.generic_table_page.table and params.generic_table_page.table.table_header %}
+        <div class="govuk-grid-column-full">
             {{ govukTable({
                 "captionClasses": "govuk-table__caption--m",
                 "firstCellIsHeader": false,
                 "head": params.generic_table_page.table.table_header,
                 "rows": params.generic_table_page.table.table_rows
             }) }}
-        {% endif %}
+        </div>
     </div>
-    <div class="govuk-grid-row">
-        {% if params.generic_table_page.pagination %}
-            {{ govukPagination(params.generic_table_page.pagination) }}
-        {% endif %}
-    </div>
+    {% if params.generic_table_page.pagination %}
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-full">
+                {{ govukPagination(params.generic_table_page.pagination) }}
+            </div>
+        </div>
+    {% endif %}
 {% endmacro %}

--- a/app/templates/macros/tablePagination.html
+++ b/app/templates/macros/tablePagination.html
@@ -1,4 +1,4 @@
-{% macro govukGenericTableTemplate(params) %}
+{% macro govukTablePagination(params) %}
 
     {% from "govuk_frontend_jinja/components/table/macro.html" import govukTable %}
     {%- from "govuk_frontend_jinja/components/pagination/macro.html" import govukPagination -%}
@@ -8,15 +8,15 @@
             {{ govukTable({
                 "captionClasses": "govuk-table__caption--m",
                 "firstCellIsHeader": false,
-                "head": params.generic_table_page.table.table_header,
-                "rows": params.generic_table_page.table.table_rows
+                "head": params.table_pagination_page.table.table_header,
+                "rows": params.table_pagination_page.table.table_rows
             }) }}
         </div>
     </div>
-    {% if params.generic_table_page.pagination %}
+    {% if params.table_pagination_page.pagination %}
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
-                {{ govukPagination(params.generic_table_page.pagination) }}
+                {{ govukPagination(params.table_pagination_page.pagination) }}
             </div>
         </div>
     {% endif %}

--- a/tests/blueprints/fund/test_routes.py
+++ b/tests/blueprints/fund/test_routes.py
@@ -144,14 +144,6 @@ def test_view_all_funds(flask_test_client, seed_dynamic_data):
     assert '<p class="govuk-body">' in html, "Description component is missing"
     assert "View all existing grants or add a new grant." in html, "Description is missing"
 
-    # Detail component availability check
-    assert '<span class="govuk-details__summary-text">' in html, "Detail summary drop down title component is missing"
-    assert "Creating new grants" in html, "Detail summary drop down title is missing"
-    assert "This is an placeholder which will be added for the grants page" in html, (
-        "Detail summary description is missing"
-    )
-    assert '<div class="govuk-details__text">' in html, "Detail summary description component is missing"
-
     # Button component availability check
     assert "Add new grant" in html, "Button text is missing"
 

--- a/tests/blueprints/round/test_routes.py
+++ b/tests/blueprints/round/test_routes.py
@@ -289,14 +289,6 @@ def test_all_applications_page(flask_test_client, seed_dynamic_data):
     assert '<p class="govuk-body">' in html, "Description component is missing"
     assert "View existing applications or create a new one." in html, "Description is missing"
 
-    # Detail component availability check
-    assert '<span class="govuk-details__summary-text">' in html, "Detail summary drop down title component is missing"
-    assert "Creating a new grant application" in html, "Detail summary drop down title is missing"
-    assert "Follow the step-by-step instructions to create a new grant application." in html, (
-        "Detail summary description is missing"
-    )
-    assert '<div class="govuk-details__text">' in html, "Detail summary description component is missing"
-
     # Button component availability check
     assert "Create new application" in html, "Button text is missing"
 

--- a/tests/shared/test_generic_table_page.py
+++ b/tests/shared/test_generic_table_page.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from app.shared.generic_table_page import GenericTablePage
+from app.shared.table_pagination import GovUKTableAndPagination
 
 MORE_THAN_DEFAULT_START_FIRST_PAGE = """
 {"items": [{"number": 1, "href": "?page=1", "current": true},
@@ -72,7 +72,7 @@ def generate_data(rows) -> list[dict]:
     ],
 )
 def test_pagination_with_less_than_pagination_default(pagination_scenario):
-    gpt = GenericTablePage(
+    gpt = GovUKTableAndPagination(
         table_header=[
             {"text": "Template Name"},
             {"text": "Tasklist Name"},
@@ -84,38 +84,38 @@ def test_pagination_with_less_than_pagination_default(pagination_scenario):
     ).__dict__
 
     if pagination_scenario["expected_pagination"] is None:  # no pagination scenarios
-        assert "pagination" not in gpt["generic_table_page"], "Pagination not available"
-        assert len(gpt["generic_table_page"]["table"]["table_rows"]) == pagination_scenario["table_row_count"], (
+        assert "pagination" not in gpt["table_pagination_page"], "Pagination not available"
+        assert len(gpt["table_pagination_page"]["table"]["table_rows"]) == pagination_scenario["table_row_count"], (
             "Invalid table row count"
         )
     else:
-        assert "pagination" in gpt["generic_table_page"], "Pagination not available"
-        assert gpt["generic_table_page"]["pagination"] == json.loads(pagination_scenario["expected_pagination"]), (
+        assert "pagination" in gpt["table_pagination_page"], "Pagination not available"
+        assert gpt["table_pagination_page"]["pagination"] == json.loads(pagination_scenario["expected_pagination"]), (
             "Pagination invalid"
         )
         # check table data row data after pagination
         match pagination_scenario["current_page"]:
             case 1:
-                assert len(gpt["generic_table_page"]["table"]["table_rows"]) == 20, "Invalid table row count"
-                assert "form_id=1" in str(gpt["generic_table_page"]["table"]["table_rows"][0][0]), (
+                assert len(gpt["table_pagination_page"]["table"]["table_rows"]) == 20, "Invalid table row count"
+                assert "form_id=1" in str(gpt["table_pagination_page"]["table"]["table_rows"][0][0]), (
                     "Not starting from correct first data"
                 )
-                assert "form_id=20" in str(gpt["generic_table_page"]["table"]["table_rows"][19][0]), (
+                assert "form_id=20" in str(gpt["table_pagination_page"]["table"]["table_rows"][19][0]), (
                     "Not ending from correct last data"
                 )
             case 2:
-                assert len(gpt["generic_table_page"]["table"]["table_rows"]) == 20, "Invalid table row count"
-                assert "form_id=21" in str(gpt["generic_table_page"]["table"]["table_rows"][0][0]), (
+                assert len(gpt["table_pagination_page"]["table"]["table_rows"]) == 20, "Invalid table row count"
+                assert "form_id=21" in str(gpt["table_pagination_page"]["table"]["table_rows"][0][0]), (
                     "Not starting from correct first data"
                 )
-                assert "form_id=40" in str(gpt["generic_table_page"]["table"]["table_rows"][19][0]), (
+                assert "form_id=40" in str(gpt["table_pagination_page"]["table"]["table_rows"][19][0]), (
                     "Not ending from correct last data"
                 )
             case 3:
-                assert len(gpt["generic_table_page"]["table"]["table_rows"]) == 5, "Invalid table row count"
-                assert "form_id=41" in str(gpt["generic_table_page"]["table"]["table_rows"][0][0]), (
+                assert len(gpt["table_pagination_page"]["table"]["table_rows"]) == 5, "Invalid table row count"
+                assert "form_id=41" in str(gpt["table_pagination_page"]["table"]["table_rows"][0][0]), (
                     "Not starting from correct first data"
                 )
-                assert "form_id=45" in str(gpt["generic_table_page"]["table"]["table_rows"][4][0]), (
+                assert "form_id=45" in str(gpt["table_pagination_page"]["table"]["table_rows"][4][0]), (
                     "Not ending from correct last data"
                 )

--- a/tests/shared/test_generic_table_page.py
+++ b/tests/shared/test_generic_table_page.py
@@ -73,12 +73,6 @@ def generate_data(rows) -> list[dict]:
 )
 def test_pagination_with_less_than_pagination_default(pagination_scenario):
     gpt = GenericTablePage(
-        page_heading="Templates",
-        page_description="Follow the step-by-step instructions to create a new grant application.",
-        detail_text="Using templates in applications",
-        detail_description="This is an placeholder which will be added for the template page",
-        button_text="Open template builder",
-        button_url="#",
         table_header=[
             {"text": "Template Name"},
             {"text": "Tasklist Name"},
@@ -91,37 +85,37 @@ def test_pagination_with_less_than_pagination_default(pagination_scenario):
 
     if pagination_scenario["expected_pagination"] is None:  # no pagination scenarios
         assert "pagination" not in gpt["generic_table_page"], "Pagination not available"
-        assert (
-            len(gpt["generic_table_page"]["table"]["table_rows"]) == pagination_scenario["table_row_count"]
-        ), "Invalid table row count"
+        assert len(gpt["generic_table_page"]["table"]["table_rows"]) == pagination_scenario["table_row_count"], (
+            "Invalid table row count"
+        )
     else:
         assert "pagination" in gpt["generic_table_page"], "Pagination not available"
-        assert gpt["generic_table_page"]["pagination"] == json.loads(
-            pagination_scenario["expected_pagination"]
-        ), "Pagination invalid"
+        assert gpt["generic_table_page"]["pagination"] == json.loads(pagination_scenario["expected_pagination"]), (
+            "Pagination invalid"
+        )
         # check table data row data after pagination
         match pagination_scenario["current_page"]:
             case 1:
                 assert len(gpt["generic_table_page"]["table"]["table_rows"]) == 20, "Invalid table row count"
-                assert "form_id=1" in str(
-                    gpt["generic_table_page"]["table"]["table_rows"][0][0]
-                ), "Not starting from correct first data"
-                assert "form_id=20" in str(
-                    gpt["generic_table_page"]["table"]["table_rows"][19][0]
-                ), "Not ending from correct last data"
+                assert "form_id=1" in str(gpt["generic_table_page"]["table"]["table_rows"][0][0]), (
+                    "Not starting from correct first data"
+                )
+                assert "form_id=20" in str(gpt["generic_table_page"]["table"]["table_rows"][19][0]), (
+                    "Not ending from correct last data"
+                )
             case 2:
                 assert len(gpt["generic_table_page"]["table"]["table_rows"]) == 20, "Invalid table row count"
-                assert "form_id=21" in str(
-                    gpt["generic_table_page"]["table"]["table_rows"][0][0]
-                ), "Not starting from correct first data"
-                assert "form_id=40" in str(
-                    gpt["generic_table_page"]["table"]["table_rows"][19][0]
-                ), "Not ending from correct last data"
+                assert "form_id=21" in str(gpt["generic_table_page"]["table"]["table_rows"][0][0]), (
+                    "Not starting from correct first data"
+                )
+                assert "form_id=40" in str(gpt["generic_table_page"]["table"]["table_rows"][19][0]), (
+                    "Not ending from correct last data"
+                )
             case 3:
                 assert len(gpt["generic_table_page"]["table"]["table_rows"]) == 5, "Invalid table row count"
-                assert "form_id=41" in str(
-                    gpt["generic_table_page"]["table"]["table_rows"][0][0]
-                ), "Not starting from correct first data"
-                assert "form_id=45" in str(
-                    gpt["generic_table_page"]["table"]["table_rows"][4][0]
-                ), "Not ending from correct last data"
+                assert "form_id=41" in str(gpt["generic_table_page"]["table"]["table_rows"][0][0]), (
+                    "Not starting from correct first data"
+                )
+                assert "form_id=45" in str(gpt["generic_table_page"]["table"]["table_rows"][4][0]), (
+                    "Not ending from correct last data"
+                )


### PR DESCRIPTION
### Change description
The GenericTablePage class/macro is doing too much and is making it difficult to accurately reproduce the designs and content.

This reduces the scope of the GenericTablePage component to only look after the table and its pagination. The rest of the template is now added into each page’s template, and this shouldn't massively increase overhead as we only have 3 of these page types.

This PR also removed the 'details' component from the View all Grants/View all Applications pages, as per the latest designs (see screenshots below).

[Jira ticket FS-4953](https://mhclgdigital.atlassian.net/browse/FS-4963)

- [X] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

### Screenshots of UI changes (if applicable)

![image](https://github.com/user-attachments/assets/b1b645b7-4167-428f-af57-90a5576278a5)

![image](https://github.com/user-attachments/assets/849767fb-74b0-4f72-8440-d235d76a5297)
