### PR TITLE
FS-4966: View templates and view templates details page

### DIFF
--- a/app/blueprints/template/routes.py
+++ b/app/blueprints/template/routes.py
@@ -77,6 +77,15 @@ def view_templates():
     return render_template("view_templates.html", **params, error=error, form_designer_url=form_designer_url)
 
 
+@template_bp.route("/<uuid:form_id>", methods=["GET"])
+def template_details(form_id):
+    """
+    Renders template details page
+    """
+    form = get_form_by_id(form_id)
+    return render_template("template_details.html", form=form)
+
+
 @template_bp.route("/<form_id>", methods=["GET", "POST"])
 def edit_template(form_id):
     template_form = TemplateFormForm()

--- a/app/blueprints/template/routes.py
+++ b/app/blueprints/template/routes.py
@@ -79,9 +79,6 @@ def view_templates():
 
 @template_bp.route("/<uuid:form_id>", methods=["GET"])
 def template_details(form_id):
-    """
-    Renders template details page
-    """
     form = get_form_by_id(form_id)
     return render_template("template_details.html", form=form)
 

--- a/app/blueprints/template/services.py
+++ b/app/blueprints/template/services.py
@@ -13,14 +13,16 @@ def build_rows(forms: list[Form]) -> list[dict]:
     rows = []
     for form in forms:
         row = [
+            # TODO move this html to template and use namespace functionality
             {
                 "html": "<a class='govuk-link--no-visited-state' "
-                f"href='{url_for('index_bp.preview_form', form_id=form.form_id)}'>{form.template_name}</a>"
+                f"href='{url_for('template_bp.template_details', form_id=form.form_id)}'>{form.template_name}</a>"
             },
             {"text": form.name_in_apply_json["en"]},
             {
+                "classes": "govuk-!-text-align-right",
                 "html": "<a class='govuk-link--no-visited-state' href='"
-                f"{url_for('template_bp.edit_template', form_id=form.form_id)}'>Edit details</a>"
+                f"{url_for('template_bp.edit_template', form_id=form.form_id)}'>Edit details</a>",
             },
         ]
         rows.append(row)

--- a/app/blueprints/template/templates/template_details.html
+++ b/app/blueprints/template/templates/template_details.html
@@ -11,15 +11,14 @@
               "text": "Back",
               "href": url_for("template_bp.view_templates")
             }) }}
-            <h2 class="govuk-heading-l">{{ form.template_name }}
-                <p class="govuk-body">
-                    <a class='govuk-link--no-visited-state'
-                       target="_blank"
-                       href='{{ url_for("index_bp.preview_form", form_id=form.form_id) }}'>
-                        Preview template (Opens in a new tab)
-                    </a>
-                </p>
-            </h2>
+            <h2 class="govuk-heading-l govuk-!-margin-bottom-2">{{ form.template_name }}</h2>
+            <p class="govuk-body govuk-!-margin-bottom-7">
+                <a class='govuk-link govuk-link--no-visited-state'
+                   target="_blank"
+                   href='{{ url_for("index_bp.preview_form", form_id=form.form_id) }}'>
+                    Preview template (opens in a new tab)
+                </a>
+            </p>
 
             {{ govukSummaryList({
                 "classes": "govuk-!-margin-bottom-1",
@@ -29,7 +28,11 @@
                         "value": {"text": form.template_name},
                         "actions": {
                             "items": [
-                                {"href": "#", "text": "Change"}
+                                {
+                                "classes": "govuk-link--no-visited-state",
+                                "href": "#",
+                                "text": "Change"
+                                }
                             ]
                         }
                     },
@@ -38,7 +41,11 @@
                         "value": {"text": form.name_in_apply_json["en"]},
                         "actions": {
                             "items": [
-                                {"href": "#", "text": "Change"}
+                                {
+                                "classes": "govuk-link--no-visited-state",
+                                "href": "#",
+                                "text": "Change"
+                                }
                             ]
                         }
                     },
@@ -47,14 +54,18 @@
                         "value": {"text": form.runner_publish_name},
                         "actions": {
                             "items": [
-                                {"href": "#", "text": "Change"}
+                                {
+                                "classes": "govuk-link--no-visited-state",
+                                "href": "#",
+                                 "text": "Change"
+                                 }
                             ]
                         }
                     }
                     ]
             }) }}
-            <p class="govuk-body">
-                <a class='govuk-link--no-visited-state'
+            <p class="govuk-body govuk-!-margin-top-8">
+                <a class='govuk-link govuk-link--no-visited-state'
                    href='#'>View template questions</a>
             </p>
         </div>

--- a/app/blueprints/template/templates/template_details.html
+++ b/app/blueprints/template/templates/template_details.html
@@ -1,0 +1,62 @@
+{% extends "base.html" %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{%- from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList -%}
+{%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
+{% set showNavigationBar = True %}
+{% set active_item_identifier = "templates" %}
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            {{ govukBackLink({
+              "text": "Back",
+              "href": url_for("template_bp.view_templates")
+            }) }}
+            <h2 class="govuk-heading-l">{{ form.template_name }}
+                <p class="govuk-body">
+                    <a class='govuk-link--no-visited-state'
+                       target="_blank"
+                       href='{{ url_for("index_bp.preview_form", form_id=form.form_id) }}'>
+                        Preview template (Opens in a new tab)
+                    </a>
+                </p>
+            </h2>
+
+            {{ govukSummaryList({
+                "classes": "govuk-!-margin-bottom-1",
+                "rows": [
+                    {
+                        "key": {"text": "Template name"},
+                        "value": {"text": form.template_name},
+                        "actions": {
+                            "items": [
+                                {"href": "#", "text": "Change"}
+                            ]
+                        }
+                    },
+                    {
+                        "key": {"text": "Task title"},
+                        "value": {"text": form.name_in_apply_json["en"]},
+                        "actions": {
+                            "items": [
+                                {"href": "#", "text": "Change"}
+                            ]
+                        }
+                    },
+                    {
+                        "key": {"text": "Template JSON file"},
+                        "value": {"text": form.runner_publish_name},
+                        "actions": {
+                            "items": [
+                                {"href": "#", "text": "Change"}
+                            ]
+                        }
+                    }
+                    ]
+            }) }}
+            <p class="govuk-body">
+                <a class='govuk-link--no-visited-state'
+                   href='#'>View template questions</a>
+            </p>
+        </div>
+    </div>
+{% endblock content %}

--- a/tests/blueprints/template/test_routes.py
+++ b/tests/blueprints/template/test_routes.py
@@ -62,7 +62,7 @@ def test_template_details_view(flask_test_client, seed_dynamic_data):
 
     # Title component availability check
     assert '<a href="/templates" class="govuk-back-link">Back</a>' in html, "Back button is missing"
-    assert "Preview template (Opens in a new tab)" in html, "Preview template is missing"
+    assert "Preview template (opens in a new tab)" in html, "Preview template is missing"
     assert f"/preview/{form.form_id}" in html, "Preview link is missing"
 
     # table titles
@@ -74,7 +74,7 @@ def test_template_details_view(flask_test_client, seed_dynamic_data):
     assert "About your organization template" in html, "Template name is missing"
     assert "About your organisation" in html, "Task title is missing"
     assert "about-your-org" in html, "Template JSON name is missing"
-    assert '<a class="govuk-link" href="#">Change</a>' in html, "Change action is missing"
+    assert '<a class="govuk-link govuk-link--no-visited-state" href="#">Change</a>' in html, "Change action is missing"
 
     # Detail component availability check
     assert "View template questions" in html, "View template questions is missing"

--- a/tests/blueprints/template/test_routes.py
+++ b/tests/blueprints/template/test_routes.py
@@ -1,5 +1,7 @@
 import pytest
 
+from app.db.models import Form
+
 
 @pytest.mark.usefixtures("set_auth_cookie", "patch_validate_token_rs256_internal_user", "db_with_templates")
 def test_generalized_table_template_with_existing_templates(flask_test_client):
@@ -45,3 +47,34 @@ def test_generalized_table_template_with_existing_templates(flask_test_client):
         "Tasklist name and table component is missing"
     )
     assert "Edit details" in html, "Edit action is missing"
+
+
+@pytest.mark.usefixtures("set_auth_cookie", "patch_validate_token_rs256_internal_user", "seed_dynamic_data")
+def test_template_details_view(flask_test_client, seed_dynamic_data):
+    form: Form = seed_dynamic_data["forms"][0]
+
+    response = flask_test_client.get(
+        f"/templates/{form.form_id}",
+    )
+
+    assert response.status_code == 200
+    html = response.data.decode("utf-8")
+
+    # Title component availability check
+    assert '<a href="/templates" class="govuk-back-link">Back</a>' in html, "Back button is missing"
+    assert "Preview template (Opens in a new tab)" in html, "Preview template is missing"
+    assert f"/preview/{form.form_id}" in html, "Preview link is missing"
+
+    # table titles
+    assert "Template name" in html, "Summary title is missing"
+    assert "Task title" in html, "Summary title is missing"
+    assert "Template JSON file" in html, "Summary title is missing"
+
+    # table data
+    assert "About your organization template" in html, "Template name is missing"
+    assert "About your organisation" in html, "Task title is missing"
+    assert "about-your-org" in html, "Template JSON name is missing"
+    assert '<a class="govuk-link" href="#">Change</a>' in html, "Change action is missing"
+
+    # Detail component availability check
+    assert "View template questions" in html, "View template questions is missing"

--- a/tests/seed_test_data.py
+++ b/tests/seed_test_data.py
@@ -426,6 +426,7 @@ def init_unit_test_data() -> dict:
         name_in_apply_json={"en": "About your organisation"},
         section_index=1,
         runner_publish_name="about-your-org",
+        template_name="About your organization template",
     )
     p1: Page = Page(
         page_id=uuid4(),


### PR DESCRIPTION
**Ticket : https://mhclgdigital.atlassian.net/browse/FS-4966**


### Change description
This PR will cover the view items page for the uploaded templates

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test

Go to the templates -> click one of the uploaded templates then you should see the details of the templates
also if you preview it should allow you to preview it in runner


### Screenshots of UI changes (if applicable)

<img width="1134" alt="image" src="https://github.com/user-attachments/assets/2a66dd86-d8dc-4820-97f1-83c67729649c" />

