### PR TITLE
Move some assets to top of static dir for GOV.UK Frontend

### DIFF
--- a/build.py
+++ b/build.py
@@ -60,23 +60,12 @@ def build_govuk_assets(static_dist_root="app/static/dist"):
     for file_to_move in os.listdir(ASSETS_PATH):
         shutil.move("/".join([ASSETS_PATH, file_to_move]), DIST_PATH)
 
-    # Update relative paths
-
-    print("Updating relative paths in css files to " + GOVUK_DIR)
-    cwd = os.getcwd()
-    os.chdir(DIST_PATH)
-    for css_file in glob.glob("*.css"):
-        # Read in the file
-        with open(css_file, "r") as file:
-            filedata = file.read()
-
-        # Replace the target string
-        filedata = filedata.replace(ASSETS_DIR, ASSETS_DIR + GOVUK_DIR)
-
-        # Write the file out again
-        with open(css_file, "w") as file:
-            file.write(filedata)
-    os.chdir(cwd)
+    # We are using pre-compiled GOV.UK Frontend at the moment, which bakes in some expected URL paths for certain
+    # assets. So here we massage some files into the correct place.
+    print("Copying images and fonts to /static for hard-coded CSS in GOV.UK Frontend")
+    shutil.copytree("app/static/dist/govuk-frontend/images", "app/static/dist/images")
+    shutil.copytree("app/static/dist/govuk-frontend/fonts", "app/static/dist/fonts")
+    shutil.copy("app/static/dist/govuk-frontend/manifest.json", "app/static/dist/manifest.json")
 
     # Delete temp files
     print("Deleting " + ASSETS_PATH)


### PR DESCRIPTION
Caught in QA of https://mhclgdigital.atlassian.net/browse/FS-4947

### Change description
Precompiled GOV.UK Frontend html and css expects some assets (eg images, fonts, manifest) to be located at specific URL paths. We could only change this by bundling GOV.UK frontend ourselves, or doing some extremely gross search+replace in the bundled assets.

Instead of both of those, we can just lift the assets into the correct place for our local static files.

## Before
<img width="1544" alt="image" src="https://github.com/user-attachments/assets/e186010e-1cb9-444c-9e6f-95099bb1156b" />


## After
<img width="1573" alt="image" src="https://github.com/user-attachments/assets/315cfcf6-8564-4f61-9914-4b54b13613cc" />
