### PR TITLE
Consistently show flashed messages on all pages

### DIFF
--- a/app/blueprints/fund/templates/view_all_funds.html
+++ b/app/blueprints/fund/templates/view_all_funds.html
@@ -4,19 +4,11 @@
 {% set active_item_identifier = "grants" %}
 
 {%- from "macros/tablePagination.html" import govukTablePagination -%}
-{% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
 {%- from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary -%}
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 
 
 {% block content %}
-    {% with messages = get_flashed_messages() %}
-        {% if messages %}
-            <div class="govuk-grid-row">
-                {{ govukNotificationBanner({"html": messages[0],"type": "success"}) }}
-            </div>
-        {% endif %}
-    {% endwith %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-l">Grants</h1>

--- a/app/blueprints/index/templates/dashboard.html
+++ b/app/blueprints/index/templates/dashboard.html
@@ -2,16 +2,8 @@
 {% set showNavigationBar = True %}
 {% set active_item_identifier = "home" %}
 
-{% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
 {% block content %}
     <div class="govuk-width-container">
-        {% with messages = get_flashed_messages() %}
-            {% if messages %}
-                <div class="govuk-grid-row">
-                    {{ govukNotificationBanner({"html": messages[0], "type": "success"}) }}
-                </div>
-            {% endif %}
-        {% endwith %}
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
                 <h1 class="govuk-heading-l">Creating a new grant application</h1>

--- a/app/blueprints/round/templates/view_all_rounds.html
+++ b/app/blueprints/round/templates/view_all_rounds.html
@@ -4,19 +4,11 @@
 {% set active_item_identifier = "applications" %}
 
 {%- from "macros/tablePagination.html" import govukTablePagination -%}
-{% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
 {%- from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary -%}
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 
 
 {% block content %}
-    {% with messages = get_flashed_messages() %}
-        {% if messages %}
-            <div class="govuk-grid-row">
-                {{ govukNotificationBanner({"html": messages[0],"type": "success"}) }}
-            </div>
-        {% endif %}
-    {% endwith %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-l">Applications</h1>

--- a/app/blueprints/template/templates/view_templates.html
+++ b/app/blueprints/template/templates/view_templates.html
@@ -5,20 +5,12 @@
 {% from "macros/wtfToGovUk.html" import input %}
 {%- from "govuk_frontend_jinja/components/file-upload/macro.html" import govukFileUpload -%}
 {%- from "macros/tablePagination.html" import govukTablePagination -%}
-{% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
 {%- from "govuk_frontend_jinja/components/details/macro.html" import govukDetails -%}
 {%- from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary -%}
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 
 
 {% block content %}
-    {% with messages = get_flashed_messages() %}
-        {% if messages %}
-            <div class="govuk-grid-row">
-                {{ govukNotificationBanner({"html": messages[0],"type": "success"}) }}
-            </div>
-        {% endif %}
-    {% endwith %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-l">Templates</h1>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,5 +1,6 @@
 {% extends "govuk_frontend_jinja/template.html" %}
 {% from "govuk_frontend_jinja/components/breadcrumbs/macro.html" import govukBreadcrumbs %}
+{% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
 {% set assetPath = url_for("static", filename="").rstrip("/") %}
 
 {% set cspNonce = csp_nonce() %}  {# Used in the base template govuk_frontend_jinja/template.html #}
@@ -34,6 +35,16 @@
 <div class="govuk-width-container {{ containerClasses }}">
   {% block beforeContent %}{% endblock beforeContent %}
   <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content" role="main"{% if mainLang %} lang="{{ mainLang }}"{% endif %}>
+    {% with messages = get_flashed_messages() %}
+        {% if messages %}
+            <div class="govuk-grid-row">
+              <div class="govuk-grid-column-full">
+                {{ govukNotificationBanner({"html": messages[0],"type": "success"}) }}
+              </div>
+            </div>
+        {% endif %}
+    {% endwith %}
+
     {% block content %}{% endblock content %}
   </main>
 </div>


### PR DESCRIPTION
Picked up in QA of https://mhclgdigital.atlassian.net/browse/FS-4925

### Change description
We use flash messages/notification banners to alert users of successful important actions.

We were handling these messages in each individual template, and only in specific templates, meaning that depending on which page you land on after a successful action, you may or may not get shown the flash message - it depends if that page is set up to show them.

This inconsistent behaviour is confusing and can lead to flash messages being shown much later, when they're no longer relevant.

Instead, let's show flash messages as part of the base template, meaning every page can show them by default.