### PR TITLE
Replace custom error handling with govuk-frontend-wtf

### DIFF
--- a/app/blueprints/application/routes.py
+++ b/app/blueprints/application/routes.py
@@ -67,12 +67,9 @@ def select_fund():
     form.fund_id.choices = choices
     if form.validate_on_submit():
         return redirect(url_for("application_bp.select_application", fund_id=form.fund_id.data))
-    error = None
-    if form.fund_id.errors:
-        error = {"titleText": "There is a problem", "errorList": [{"text": form.fund_id.errors[0], "href": "#fund_id"}]}
     select_items = [{"value": value, "text": text} for value, text in choices]
     return render_template(
-        "select_fund.html", form=form, error=error, select_items=select_items, back_link=url_for("index_bp.dashboard")
+        "select_fund.html", form=form, select_items=select_items, back_link=url_for("index_bp.dashboard")
     )
 
 
@@ -92,14 +89,8 @@ def select_application():
     form.round_id.choices = choices
     if form.validate_on_submit():
         return redirect(url_for("application_bp.build_application", round_id=form.round_id.data))
-    error = None
-    if form.round_id.errors:
-        error = {
-            "titleText": "There is a problem",
-            "errorList": [{"text": form.round_id.errors[0], "href": "#round_id"}],
-        }
     select_items = [{"value": value, "text": text} for value, text in choices]
-    return render_template("select_application.html", form=form, fund=fund, error=error, select_items=select_items)
+    return render_template("select_application.html", form=form, fund=fund, select_items=select_items)
 
 
 @application_bp.route("/<round_id>/sections")

--- a/app/blueprints/fund/routes.py
+++ b/app/blueprints/fund/routes.py
@@ -12,7 +12,7 @@ from app.blueprints.fund.forms import FundForm
 from app.blueprints.fund.services import build_fund_rows
 from app.db.models.fund import Fund, FundingType
 from app.db.queries.fund import add_fund, get_all_funds, get_fund_by_id, update_fund
-from app.shared.helpers import all_funds_as_govuk_select_items, error_formatter, flash_message
+from app.shared.helpers import all_funds_as_govuk_select_items, flash_message
 from app.shared.table_pagination import GovUKTableAndPagination
 
 INDEX_BP_DASHBOARD = "index_bp.dashboard"
@@ -99,8 +99,7 @@ def create_fund():
             case _:
                 return redirect(url_for("round_bp.create_round", fund_id=new_fund.fund_id))
 
-    error = error_formatter(form)
-    return render_template("fund.html", form=form, fund_id=None, error=error)
+    return render_template("fund.html", form=form, fund_id=None)
 
 
 @fund_bp.route("/<uuid:fund_id>/edit", methods=["GET", "POST"])
@@ -148,5 +147,4 @@ def edit_fund(fund_id):
             return redirect(url_for(INDEX_BP_DASHBOARD))
         return redirect(url_for("fund_bp.view_fund_details", fund_id=fund.fund_id))
 
-    error = error_formatter(form)
-    return render_template("fund.html", form=form, fund_id=fund_id, error=error)
+    return render_template("fund.html", form=form, fund_id=fund_id)

--- a/app/blueprints/fund/templates/fund.html
+++ b/app/blueprints/fund/templates/fund.html
@@ -9,13 +9,8 @@
 {% block content %}
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-        {% if error %}
-            {{
-            govukErrorSummary({
-                "titleText": error.titleText,
-                "errorList": error.errorList
-            })
-            }}
+        {% if form.errors %}
+          {{ govukErrorSummary(wtforms_errors(form)) }}
         {% endif %}
         <h1 class="govuk-heading-l">{{pageHeading}}</h1>
         <div class="govuk-form-group">

--- a/app/blueprints/fund/templates/view_all_funds.html
+++ b/app/blueprints/fund/templates/view_all_funds.html
@@ -4,7 +4,6 @@
 {% set active_item_identifier = "grants" %}
 
 {%- from "macros/tablePagination.html" import govukTablePagination -%}
-{%- from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary -%}
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 
 

--- a/app/blueprints/round/routes.py
+++ b/app/blueprints/round/routes.py
@@ -21,7 +21,7 @@ from app.db.queries.clone import clone_single_round
 from app.db.queries.fund import get_all_funds, get_fund_by_id
 from app.db.queries.round import get_all_rounds, get_round_by_id
 from app.shared.forms import SelectFundForm
-from app.shared.helpers import error_formatter, flash_message
+from app.shared.helpers import flash_message
 from app.shared.table_pagination import GovUKTableAndPagination
 
 INDEX_BP_DASHBOARD = "index_bp.dashboard"
@@ -105,8 +105,7 @@ def create_round():
         "fund": fund,
         "round_id": None,  # Since we're creating a new round, there's no round ID yet
     }
-    error = error_formatter(form)
-    return render_template("round.html", **params, error=error)
+    return render_template("round.html", **params)
 
 
 @round_bp.route("/<round_id>/edit", methods=["GET", "POST"])
@@ -131,8 +130,7 @@ def edit_round(round_id):
         "fund": get_fund_by_id(existing_round.fund_id),
         "round_id": round_id,
     }
-    error = error_formatter(form)
-    return render_template("round.html", **params, error=error)
+    return render_template("round.html", **params)
 
 
 @round_bp.route("/<round_id>/clone", methods=["POST"])

--- a/app/blueprints/round/templates/round.html
+++ b/app/blueprints/round/templates/round.html
@@ -11,11 +11,8 @@
 {% block content %}
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-        {% if error %}
-            {{ govukErrorSummary({
-                "titleText": error.titleText,
-                "errorList": error.errorList
-            }) }}
+        {% if form.errors %}
+          {{ govukErrorSummary(wtforms_errors(form)) }}
         {% endif %}
         <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
         <p class="govuk-body govuk-!-margin-bottom-1">Grant: <a href="{{ url_for('fund_bp.edit_fund', fund_id=fund.fund_id) }}" class="govuk-link">{{ fund.title_json["en"] }}</a></p>

--- a/app/blueprints/round/templates/view_all_rounds.html
+++ b/app/blueprints/round/templates/view_all_rounds.html
@@ -4,7 +4,6 @@
 {% set active_item_identifier = "applications" %}
 
 {%- from "macros/tablePagination.html" import govukTablePagination -%}
-{%- from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary -%}
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 
 

--- a/app/blueprints/template/routes.py
+++ b/app/blueprints/template/routes.py
@@ -13,7 +13,6 @@ from app.db.queries.application import (
     get_form_by_template_name,
     update_form,
 )
-from app.shared.helpers import error_formatter
 from app.shared.table_pagination import GovUKTableAndPagination
 
 template_bp = Blueprint(
@@ -71,10 +70,7 @@ def view_templates():
 
         return redirect(url_for("template_bp.view_templates"))
 
-    error = None
-    if "uploadform" in params:
-        error = error_formatter(params["uploadform"])
-    return render_template("view_templates.html", **params, error=error, form_designer_url=form_designer_url)
+    return render_template("view_templates.html", **params, form_designer_url=form_designer_url)
 
 
 @template_bp.route("/<uuid:form_id>", methods=["GET"])
@@ -102,11 +98,9 @@ def edit_template(form_id):
     template_form.tasklist_name.data = existing_form.name_in_apply_json["en"]
     template_form.url_path.data = existing_form.runner_publish_name
     params = {"template_form": template_form}
-    error = error_formatter(template_form)
     return render_template(
         "edit_form_template.html",
         **params,
-        error=error,
     )
 
 

--- a/app/blueprints/template/templates/edit_form_template.html
+++ b/app/blueprints/template/templates/edit_form_template.html
@@ -10,13 +10,8 @@ Edit Template
 {% endset %}
 {% block content %}
 <div class="govuk-grid-row">
-    {% if error %}
-        {{
-        govukErrorSummary({
-            "titleText": error.titleText,
-            "errorList": error.errorList
-        })
-        }}
+    {% if template_form.errors %}
+      {{ govukErrorSummary(wtforms_errors(template_form)) }}
     {% endif %}
     <h1 class="govuk-heading-l">{{pageHeading}}</h1>
 </div>

--- a/app/blueprints/template/templates/view_templates.html
+++ b/app/blueprints/template/templates/view_templates.html
@@ -6,11 +6,13 @@
 {%- from "govuk_frontend_jinja/components/file-upload/macro.html" import govukFileUpload -%}
 {%- from "macros/tablePagination.html" import govukTablePagination -%}
 {%- from "govuk_frontend_jinja/components/details/macro.html" import govukDetails -%}
-{%- from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary -%}
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 
 
 {% block content %}
+    {% if uploadform.errors %}
+      {{ govukErrorSummary(wtforms_errors(uploadform)) }}
+    {% endif %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-l">Templates</h1>

--- a/app/shared/helpers.py
+++ b/app/shared/helpers.py
@@ -41,22 +41,6 @@ def get_all_pages_in_parent_form(db, page_id):
     return page_ids
 
 
-# This formatter will read all the errors and then convert them to the required format to support error-summary display
-def error_formatter(form):
-    errors_list = []
-    for field, error_messages in form.errors.items():
-        field_name = getattr(form, field).label.text
-        if isinstance(error_messages, list):
-            errors_list.extend({"text": f"{field_name}: {err}", "href": f"#{field}"} for err in error_messages)
-        elif isinstance(error_messages, dict) and any(
-            error_messages.get(k) for k in ["day", "month", "years", "hour", "minute"]
-        ):
-            errors_list.append({"text": f"{field_name}: Enter valid datetime", "href": f"#{field}"})
-    if errors_list:
-        return {"titleText": "There is a problem", "errorList": errors_list}
-    return None
-
-
 # Custom validator to check for spaces between letters
 def no_spaces_between_letters(form, field):
     # Regular expression to check for spaces between letters

--- a/app/templates/select_application.html
+++ b/app/templates/select_application.html
@@ -13,12 +13,8 @@
       "href": url_for("application_bp.select_fund")
     }) }}
 
-    {% if error %}
-      {{ govukErrorSummary({
-        "titleText": error.titleText,
-        "errorList": error.errorList,
-        "classes": "govuk-!-margin-bottom-4"
-      }) }}
+    {% if form.errors %}
+      {{ govukErrorSummary(wtforms_errors(form)) }}
     {% endif %}
 
     <span class="govuk-caption-m">{{ fund.short_name + " - " + fund.title_json["en"] }}</span>

--- a/app/templates/select_fund.html
+++ b/app/templates/select_fund.html
@@ -11,12 +11,8 @@
       "text": "Back",
       "href": back_link
     }) }}
-    {% if error %}
-      {{ govukErrorSummary({
-        "titleText": error.titleText,
-        "errorList": error.errorList,
-        "classes": "govuk-!-margin-bottom-4"
-      }) }}
+    {% if form.errors %}
+      {{ govukErrorSummary(wtforms_errors(form)) }}
     {% endif %}
 
     <h1 class="govuk-heading-l">Select a grant</h1>

--- a/tests/blueprints/fund/test_routes.py
+++ b/tests/blueprints/fund/test_routes.py
@@ -70,7 +70,7 @@ def test_create_fund_with_existing_short_name(flask_test_client):
     response = submit_form(flask_test_client, "/grants/create", create_data)
     assert response.status_code == 200
     html = response.data.decode("utf-8")
-    assert '<a href="#short_name">Short name: Given fund short name already exists.</a>' in html, (
+    assert '<a href="#short_name">Given fund short name already exists.</a>' in html, (
         "Not having the fund short name already exists error"
     )
 

--- a/tests/blueprints/round/test_routes.py
+++ b/tests/blueprints/round/test_routes.py
@@ -78,9 +78,7 @@ def test_create_round_with_existing_short_name(flask_test_client, seed_dynamic_d
         "guidance_url": "http://example.com/guidance",
     }
 
-    error_html = (
-        '<a href="#short_name">Short name: Given short name already exists in the fund funding to improve testing.</a>'
-    )
+    error_html = '<a href="#short_name">Given short name already exists in the fund funding to improve testing.</a>'
     url = f"/rounds/create?fund_id={test_fund.fund_id}"
 
     # Test works fine with first round


### PR DESCRIPTION
Let's remove some more of our custom code and rely on govuk-frontend-wtf to do the heavy and consistent lifting.

Visually everything should be unchanged, except some error messages which no longer have the <field_name> prefix. We have [a ticket to rationalise all error messages](https://mhclgdigital.atlassian.net/browse/FS-4967) later, so I'm ok with this.