### PR TITLE
FS-4970: Update Application add and edit api and template

### DIFF
--- a/app/blueprints/fund/routes.py
+++ b/app/blueprints/fund/routes.py
@@ -18,6 +18,7 @@ from app.shared.table_pagination import GovUKTableAndPagination
 INDEX_BP_DASHBOARD = "index_bp.dashboard"
 SELECT_GRANT_PAGE = "select_grant"
 APPLICATIONS_DETAIL_PAGE = "view_application"
+APPLICATION_EDIT_PAGE = "edit_application"
 FUND_LIST_PAGE = "grants_table"
 FUND_DETAILS_ROUTE = "fund_bp.view_fund_details"
 
@@ -112,7 +113,8 @@ def create_fund():
 def _edit_fund_get_previous_url(actions, fund_id, round_id):
     if actions == APPLICATIONS_DETAIL_PAGE:
         return url_for("round_bp.round_details", round_id=round_id)
-
+    if actions == APPLICATION_EDIT_PAGE:
+        return url_for("round_bp.edit_round", round_id=round_id)
     return url_for(FUND_DETAILS_ROUTE, fund_id=fund_id)
 
 

--- a/app/blueprints/index/templates/dashboard.html
+++ b/app/blueprints/index/templates/dashboard.html
@@ -22,7 +22,7 @@
                 <li>
                     <p class="govuk-body govuk-!-margin-bottom-0">
                         <a class="govuk-link govuk-!-font-weight-bold govuk-link--no-visited-state"
-                           href="{{ url_for('round_bp.select_fund') }}">2. Set up a new application</a>
+                           href="{{ url_for('round_bp.select_fund', action="return_home") }}">2. Set up a new application</a>
                     </p>
                     <p class="govuk-body">
                         Set up an application with details such as deadlines and the prospectus link.

--- a/app/blueprints/round/forms.py
+++ b/app/blueprints/round/forms.py
@@ -2,8 +2,8 @@ import json
 import re
 
 from flask_wtf import FlaskForm, Form
-from govuk_frontend_wtf.wtforms_widgets import GovRadioInput, GovTextArea, GovTextInput
-from wtforms import HiddenField, RadioField, StringField, TextAreaField, URLField
+from govuk_frontend_wtf.wtforms_widgets import GovRadioInput, GovSubmitInput, GovTextArea, GovTextInput
+from wtforms import HiddenField, RadioField, StringField, SubmitField, TextAreaField, URLField
 from wtforms.fields.datetime import DateTimeField
 from wtforms.validators import DataRequired, Length, ValidationError
 
@@ -113,140 +113,190 @@ class RoundForm(FlaskForm):
 
     round_id = HiddenField("Round ID")
     fund_id = HiddenField("Fund", validators=[DataRequired()])
-    title_en = StringField("Title", widget=GovTextInput(), validators=[DataRequired()])
-    title_cy = StringField("Title (Welsh)", widget=GovTextInput())
+    title_en = StringField(
+        "Application round", widget=GovTextInput(), description="For example, Round 3", validators=[DataRequired()]
+    )
+    title_cy = StringField("Application round (Welsh)", widget=GovTextInput(), description="For example, Round 3")
     short_name = StringField(
-        "Short name",
+        "Round short name",
         widget=GovTextInput(),
-        description="Choose a unique short name with 6 or fewer characters",
+        description="Choose a unique short name with a maximum of 6 characters",
         validators=[DataRequired(), Length(max=6), no_spaces_between_letters, validate_unique_round_short_name],
     )
     opens = DateTimeField(
-        "Opens",
+        "Application round opens",
         widget=GovDatetimeInput(),
         format="%d %m %Y %H %M",
         validators=[DataRequired(message="Enter a valid date and time")],
     )
     deadline = DateTimeField(
-        "Deadline",
-        widget=GovDatetimeInput(),
-        format="%d %m %Y %H %M",
-        validators=[DataRequired(message="Enter a valid date and time")],
-    )
-    assessment_start = DateTimeField(
-        "Assessment start date",
+        "Application round closes",
         widget=GovDatetimeInput(),
         format="%d %m %Y %H %M",
         validators=[DataRequired(message="Enter a valid date and time")],
     )
     reminder_date = DateTimeField(
-        "Reminder date",
+        "Application reminder email",
+        widget=GovDatetimeInput(),
+        format="%d %m %Y %H %M",
+        validators=[DataRequired(message="Enter a valid date and time")],
+    )
+    assessment_start = DateTimeField(
+        "Assessment opens",
         widget=GovDatetimeInput(),
         format="%d %m %Y %H %M",
         validators=[DataRequired(message="Enter a valid date and time")],
     )
     assessment_deadline = DateTimeField(
-        "Assessment deadline",
+        "Assessment closes",
         widget=GovDatetimeInput(),
         format="%d %m %Y %H %M",
         validators=[DataRequired(message="Enter a valid date and time")],
     )
+    guidance_url = URLField(
+        "Assessor guidance link (optional)", widget=GovTextInput(), validators=[validate_flexible_url]
+    )
+    contact_email = StringField("Grant team email address (optional)", widget=GovTextInput())
+    contact_phone = StringField("Grant team phone number (optional)", widget=GovTextInput())
+    contact_textphone = StringField("Grant team text phone number (optional)", widget=GovTextInput())
+    support_times = StringField("Grant team support hours", widget=GovTextInput(), validators=[DataRequired()])
+    support_days = StringField("Grant team support days", widget=GovTextInput(), validators=[DataRequired()])
+    instructions_en = TextAreaField("Before you apply guidance (optional)", widget=GovTextArea())
+    instructions_cy = StringField("Before you apply guidance (Welsh)(optional)", widget=GovTextInput())
+    application_guidance_en = TextAreaField("Completing the application guidance", widget=GovTextArea())
+    application_guidance_cy = TextAreaField(
+        "Completing the application guidance (Welsh)(optional)", widget=GovTextArea()
+    )
+    feedback_link = URLField("Feedback link (optional)", widget=GovTextInput(), validators=[validate_flexible_url])
     prospectus_link = URLField(
         "Prospectus link", widget=GovTextInput(), validators=[DataRequired(), validate_flexible_url]
     )
     privacy_notice_link = URLField(
         "Privacy notice link", widget=GovTextInput(), validators=[DataRequired(), validate_flexible_url]
     )
-    application_reminder_sent = RadioField(
-        widget=GovRadioInput(), choices=[("true", "Yes"), ("false", "No")], default="false"
+    project_name_field_id = StringField(
+        "Project name field ID",
+        widget=GovTextInput(),
+        description="Ask a developer on your team for the correct field ID",
+        validators=[DataRequired()],
+    )
+    eoi_decision_schema_en = TextAreaField(
+        "Expression of interest decision schema (optional)",
+        widget=GovTextArea(),
+        validators=[validate_json_field],
+        description=JSON_FIELD_HINT,
+    )
+    eoi_decision_schema_cy = TextAreaField(
+        "Expression of interest decision schema (Welsh)(optional)",
+        widget=GovTextArea(),
+        description=JSON_FIELD_HINT,
+        validators=[validate_json_field],
     )
     contact_us_banner_en = TextAreaField(
-        "Contact Us banner",
+        "Contact Us information (optional)",
         widget=GovTextArea(),
         description="HTML to display to override the default 'Contact Us' page content",
     )
-    contact_us_banner_cy = TextAreaField("Contact Us banner (Welsh)", widget=GovTextArea())
+    contact_us_banner_cy = TextAreaField(
+        "Contact Us information (Welsh)(optional)",
+        widget=GovTextArea(),
+        description="HTML to display to override the default 'Contact Us' page content",
+    )
     reference_contact_page_over_email = RadioField(
-        "Reference contact page over email",
+        "Do you want to include the contact us page in applicant emails",
         widget=GovRadioInput(),
         choices=[("true", "Yes"), ("false", "No")],
+        coerce=lambda value: value == "true",
         default="false",
     )
-    contact_email = StringField("Grant team email address", widget=GovTextInput())
-    contact_phone = StringField("Grant team phone number", widget=GovTextInput())
-    contact_textphone = StringField("Grant team text phone number", widget=GovTextInput())
-    support_times = StringField("Support times for applicants", widget=GovTextInput(), validators=[DataRequired()])
-    support_days = StringField("Support days", widget=GovTextInput(), validators=[DataRequired()])
-    instructions_en = TextAreaField("Instructions", widget=GovTextArea())
-    instructions_cy = StringField("Instructions (Welsh)", widget=GovTextInput())
-    feedback_link = URLField("Feedback link", widget=GovTextInput(), validators=[validate_flexible_url])
-    project_name_field_id = StringField("Project name field ID", widget=GovTextInput(), validators=[DataRequired()])
-    application_guidance_en = TextAreaField("Application guidance", widget=GovTextArea())
-    application_guidance_cy = TextAreaField("Application guidance (Welsh)", widget=GovTextArea())
-    guidance_url = URLField("Guidance link", widget=GovTextInput(), validators=[validate_flexible_url])
-    all_uploaded_documents_section_available = RadioField(
-        widget=GovRadioInput(), choices=[("true", "Yes"), ("false", "No")], default="false"
-    )
     application_fields_download_available = RadioField(
-        "Application fields download available",
+        "Do you want to allow assessors to download application fields?",
         widget=GovRadioInput(),
         choices=[("true", "Yes"), ("false", "No")],
+        coerce=lambda value: value == "true",
         default="false",
     )
     display_logo_on_pdf_exports = RadioField(
-        "Display logo on PDF exports",
+        "Do you want to have the MHCLG logo on PDFs?",
         widget=GovRadioInput(),
         choices=[("true", "Yes"), ("false", "No")],
+        coerce=lambda value: value == "true",
         default="false",
     )
     mark_as_complete_enabled = RadioField(
-        "Mark as complete enabled", widget=GovRadioInput(), choices=[("true", "Yes"), ("false", "No")], default="false"
-    )
-    is_expression_of_interest = RadioField(
-        "Is expression of interest", widget=GovRadioInput(), choices=[("true", "Yes"), ("false", "No")], default="false"
-    )
-    has_feedback_survey = RadioField(
-        "Has feedback survey", widget=GovRadioInput(), choices=[("true", "Yes"), ("false", "No")], default="false"
-    )
-    has_section_feedback = RadioField(
-        "Has section feedback", widget=GovRadioInput(), choices=[("true", "Yes"), ("false", "No")], default="false"
-    )
-    has_research_survey = RadioField(
-        "Has research survey", widget=GovRadioInput(), choices=[("true", "Yes"), ("false", "No")], default="false"
-    )
-    is_feedback_survey_optional = RadioField(
-        "Is feedback survey optional",
+        "Do you want applicants to mark sections as complete?",
         widget=GovRadioInput(),
         choices=[("true", "Yes"), ("false", "No")],
+        coerce=lambda value: value == "true",
         default="false",
     )
-    is_section_feedback_optional = RadioField(
-        "Is section feedback optional",
+    is_expression_of_interest = RadioField(
+        "Is this application round an expression of interest?",
         widget=GovRadioInput(),
         choices=[("true", "Yes"), ("false", "No")],
+        coerce=lambda value: value == "true",
+        default="false",
+    )
+    has_feedback_survey = RadioField(
+        "Do you want to include a feedback survey?",
+        widget=GovRadioInput(),
+        choices=[("true", "Yes"), ("false", "No")],
+        coerce=lambda value: value == "true",
+        default="false",
+    )
+    is_feedback_survey_optional = RadioField(
+        "Is the feedback survey optional?",
+        widget=GovRadioInput(),
+        choices=[("true", "Yes"), ("false", "No")],
+        coerce=lambda value: value == "true",
+        default="false",
+    )
+    has_research_survey = RadioField(
+        "Do you want to include a research survey?",
+        widget=GovRadioInput(),
+        choices=[("true", "Yes"), ("false", "No")],
+        coerce=lambda value: value == "true",
         default="false",
     )
     is_research_survey_optional = RadioField(
         "Is research survey optional",
         widget=GovRadioInput(),
         choices=[("true", "Yes"), ("false", "No")],
+        coerce=lambda value: value == "true",
         default="false",
     )
     eligibility_config = RadioField(
-        "Has eligibility config", widget=GovRadioInput(), choices=[("true", "Yes"), ("false", "No")], default="false"
+        "Do applicants need to pass eligibility questions before applying?",
+        widget=GovRadioInput(),
+        choices=[("true", "Yes"), ("false", "No")],
+        coerce=lambda value: value == "true",
+        default="false",
     )
-    eoi_decision_schema_en = TextAreaField(
-        "EOI decision schema",
-        widget=GovTextArea(),
-        validators=[validate_json_field],
-        description=JSON_FIELD_HINT,
+    has_section_feedback = RadioField(
+        "Has section feedback",
+        widget=GovRadioInput(),
+        choices=[("true", "Yes"), ("false", "No")],
+        coerce=lambda value: value == "true",
+        default="false",
     )
-    eoi_decision_schema_cy = TextAreaField(
-        "EOI decision schema (Welsh)",
-        widget=GovTextArea(),
-        description="Leave blank for English-only funds",
-        validators=[validate_json_field],
+    is_section_feedback_optional = RadioField(
+        "Is section feedback optional",
+        widget=GovRadioInput(),
+        choices=[("true", "Yes"), ("false", "No")],
+        coerce=lambda value: value == "true",
+        default="false",
     )
+    all_uploaded_documents_section_available = RadioField(
+        widget=GovRadioInput(),
+        choices=[("true", "Yes"), ("false", "No")],
+        coerce=lambda value: value == "true",
+        default="false",
+    )
+    application_reminder_sent = RadioField(
+        widget=GovRadioInput(), choices=[("true", "Yes"), ("false", "No")], default="false"
+    )
+    save_and_continue = SubmitField("Save and continue", widget=GovSubmitInput())
+    save_and_return_home = SubmitField("Save and return home", widget=GovSubmitInput())
 
 
 class CloneRoundForm(FlaskForm):

--- a/app/blueprints/round/services.py
+++ b/app/blueprints/round/services.py
@@ -142,12 +142,12 @@ def update_existing_round(round_obj, form, user="dummy_user"):
     round_obj.title_json = {"en": form.title_en.data or None, "cy": form.title_cy.data or None}
     round_obj.short_name = form.short_name.data
     round_obj.feedback_survey_config = {
-        "has_feedback_survey": form.has_feedback_survey.data == "true",
-        "has_section_feedback": form.has_section_feedback.data == "true",
-        "has_research_survey": form.has_research_survey.data == "true",
-        "is_feedback_survey_optional": form.is_feedback_survey_optional.data == "true",
-        "is_section_feedback_optional": form.is_section_feedback_optional.data == "true",
-        "is_research_survey_optional": form.is_research_survey_optional.data == "true",
+        "has_feedback_survey": form.has_feedback_survey.data,
+        "has_section_feedback": form.has_section_feedback.data,
+        "has_research_survey": form.has_research_survey.data,
+        "is_feedback_survey_optional": form.is_feedback_survey_optional.data,
+        "is_section_feedback_optional": form.is_section_feedback_optional.data,
+        "is_research_survey_optional": form.is_research_survey_optional.data,
     }
 
     # IMPORTANT: convert date sub-form dicts into Python datetime objects
@@ -159,7 +159,7 @@ def update_existing_round(round_obj, form, user="dummy_user"):
 
     round_obj.prospectus_link = form.prospectus_link.data
     round_obj.privacy_notice_link = form.privacy_notice_link.data
-    round_obj.reference_contact_page_over_email = form.reference_contact_page_over_email.data == "true"
+    round_obj.reference_contact_page_over_email = form.reference_contact_page_over_email.data
     round_obj.contact_email = form.contact_email.data
     round_obj.contact_phone = form.contact_phone.data
     round_obj.contact_textphone = form.contact_textphone.data
@@ -168,11 +168,11 @@ def update_existing_round(round_obj, form, user="dummy_user"):
     round_obj.feedback_link = form.feedback_link.data
     round_obj.project_name_field_id = form.project_name_field_id.data
     round_obj.guidance_url = form.guidance_url.data
-    round_obj.all_uploaded_documents_section_available = form.all_uploaded_documents_section_available.data == "true"
-    round_obj.application_fields_download_available = form.application_fields_download_available.data == "true"
-    round_obj.display_logo_on_pdf_exports = form.display_logo_on_pdf_exports.data == "true"
-    round_obj.mark_as_complete_enabled = form.mark_as_complete_enabled.data == "true"
-    round_obj.is_expression_of_interest = form.is_expression_of_interest.data == "true"
+    round_obj.all_uploaded_documents_section_available = form.all_uploaded_documents_section_available.data
+    round_obj.application_fields_download_available = form.application_fields_download_available.data
+    round_obj.display_logo_on_pdf_exports = form.display_logo_on_pdf_exports.data
+    round_obj.mark_as_complete_enabled = form.mark_as_complete_enabled.data
+    round_obj.is_expression_of_interest = form.is_expression_of_interest.data
     round_obj.contact_us_banner_json = {
         "en": form.contact_us_banner_en.data or None,
         "cy": form.contact_us_banner_cy.data or None,
@@ -182,7 +182,7 @@ def update_existing_round(round_obj, form, user="dummy_user"):
         "en": form.application_guidance_en.data or None,
         "cy": form.application_guidance_cy.data or None,
     }
-    round_obj.eligibility_config = {"has_eligibility": form.eligibility_config.data == "true"}
+    round_obj.eligibility_config = {"has_eligibility": form.eligibility_config.data}
     round_obj.eoi_decision_schema = {
         "en": convert_form_data_to_json(form.eoi_decision_schema_en.data),
         "cy": convert_form_data_to_json(form.eoi_decision_schema_cy.data),
@@ -209,7 +209,7 @@ def create_new_round(form, user="dummy_user"):
             "en": form.contact_us_banner_en.data or None,
             "cy": form.contact_us_banner_cy.data or None,
         },
-        reference_contact_page_over_email=form.reference_contact_page_over_email.data == "true",
+        reference_contact_page_over_email=form.reference_contact_page_over_email.data,
         contact_email=form.contact_email.data,
         contact_phone=form.contact_phone.data,
         contact_textphone=form.contact_textphone.data,
@@ -223,20 +223,20 @@ def create_new_round(form, user="dummy_user"):
             "cy": form.application_guidance_cy.data or None,
         },
         guidance_url=form.guidance_url.data,
-        all_uploaded_documents_section_available=form.all_uploaded_documents_section_available.data == "true",
-        application_fields_download_available=form.application_fields_download_available.data == "true",
-        display_logo_on_pdf_exports=form.display_logo_on_pdf_exports.data == "true",
-        mark_as_complete_enabled=form.mark_as_complete_enabled.data == "true",
-        is_expression_of_interest=form.is_expression_of_interest.data == "true",
+        all_uploaded_documents_section_available=form.all_uploaded_documents_section_available.data,
+        application_fields_download_available=form.application_fields_download_available.data,
+        display_logo_on_pdf_exports=form.display_logo_on_pdf_exports.data,
+        mark_as_complete_enabled=form.mark_as_complete_enabled.data,
+        is_expression_of_interest=form.is_expression_of_interest.data,
         feedback_survey_config={
-            "has_feedback_survey": form.has_feedback_survey.data == "true",
-            "has_section_feedback": form.has_section_feedback.data == "true",
-            "has_research_survey": form.has_research_survey.data == "true",
-            "is_feedback_survey_optional": form.is_feedback_survey_optional.data == "true",
-            "is_section_feedback_optional": form.is_section_feedback_optional.data == "true",
-            "is_research_survey_optional": form.is_research_survey_optional.data == "true",
+            "has_feedback_survey": form.has_feedback_survey.data,
+            "has_section_feedback": form.has_section_feedback.data,
+            "has_research_survey": form.has_research_survey.data,
+            "is_feedback_survey_optional": form.is_feedback_survey_optional.data,
+            "is_section_feedback_optional": form.is_section_feedback_optional.data,
+            "is_research_survey_optional": form.is_research_survey_optional.data,
         },
-        eligibility_config={"has_eligibility": form.eligibility_config.data == "true"},
+        eligibility_config={"has_eligibility": form.eligibility_config.data},
         eoi_decision_schema={
             "en": convert_form_data_to_json(form.eoi_decision_schema_en.data),
             "cy": convert_form_data_to_json(form.eoi_decision_schema_cy.data),

--- a/app/blueprints/round/templates/round.html
+++ b/app/blueprints/round/templates/round.html
@@ -1,36 +1,64 @@
 {% extends "base.html" %}
-{% set pageHeading %}{{ 'Update a Round' if round_id else 'Create a Round' }}{% endset %}
+{% set pageHeading %}
+{{ 'Apply for ' + fund.title_json["en"]  if round_id else 'Create a new application' }}{% endset %}
 
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
+{%- from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink -%}
 {%- from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary -%}
+{% block beforeContent %}
+    {{ super() }}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            {{ govukBackLink({
+              "text": "Back",
+              "href": prev_nav_url
+            }) }}
+        </div>
+    </div>
+{% endblock beforeContent %}
 {% block content %}
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         {% if form.errors %}
           {{ govukErrorSummary(wtforms_errors(form)) }}
         {% endif %}
-        <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
-        <p class="govuk-body govuk-!-margin-bottom-1">Grant: <a href="{{ url_for('fund_bp.edit_fund', fund_id=fund.fund_id) }}" class="govuk-link">{{ fund.title_json["en"] }}</a></p>
-        <p class="govuk-body govuk-!-margin-bottom-7">
-            <a href="{{ url_for('round_bp.select_fund') }}" class="govuk-link">Change grant</a>
+        </div>
+</div>
+<div class="govuk-grid-row">
+<div class="govuk-grid-column-full">
+        {% if round_id %}
+            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">{{ pageHeading }}</h1>
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('fund_bp.edit_fund', fund_id=fund.fund_id,  actions="edit_application", round_id=round_id, _anchor=fund_form.title_en.id) }}">Change application heading</a>
+            <p class="govuk-body govuk-!-margin-top-7">Grant: {{ fund.title_json["en"] }}</p>
+        {% else %}
+            <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ pageHeading }}</h1>
+            <p class="govuk-body govuk-!-margin-bottom-0">Grant: {{ fund.title_json["en"] }}</p>
+            <p class="govuk-body govuk-!-margin-bottom-7">
+            <a href="{{ url_for('round_bp.select_fund') }}" class="govuk-link govuk-link--no-visited-state">Change grant</a>
         </p>
+        {% endif %}
+
+    </div>
+</div>
+<div class="govuk-grid-row govuk-!-margin-top-3">
+    <div class="govuk-grid-column-full">
         <div class="govuk-form-group">
             <fieldset class="govuk-fieldset">
                 <form method="POST" novalidate>
                     {{form.hidden_tag()}}
+                    <div class="govuk-heading-m">Round details</div>
                     {{form.title_en}}
                     {{form.title_cy(params={"classes": "welsh-field"})}}
                     {{form.short_name}}
+                     <div class="govuk-heading-m">Application dates</div>
                     {{form.opens()}}
                     {{form.deadline()}}
-                    {{form.assessment_start()}}
                     {{form.reminder_date()}}
+                    <div class="govuk-heading-m">Assessment details</div>
+                    {{form.assessment_start()}}
                     {{form.assessment_deadline()}}
-                    {{form.prospectus_link}}
-                    {{form.privacy_notice_link}}
-                    {{form.contact_us_banner_en }}
-                    {{form.contact_us_banner_cy(params={"classes": "welsh-field"}) }}
-                    {{form.reference_contact_page_over_email}}
+                    {{form.guidance_url}}
+                    <div class="govuk-heading-m">Applicant support details</div>
                     {{form.contact_email}}
                     {{form.contact_phone}}
                     {{form.contact_textphone}}
@@ -38,46 +66,38 @@
                     {{form.support_days}}
                     {{form.instructions_en }}
                     {{form.instructions_cy(params={"classes":"welsh-field"}) }}
-                    {{form.feedback_link}}
-                    {{form.project_name_field_id}}
                     {{form.application_guidance_en}}
                     {{form.application_guidance_cy(params={"classes": "welsh-field"}) }}
-                    {{form.guidance_url}}
+                    {{form.feedback_link}}
+                    {{form.prospectus_link}}
+                    {{form.privacy_notice_link}}
+                     <div class="govuk-heading-m">Advanced settings</div>
+                    {{form.project_name_field_id}}
+                    {{form.eoi_decision_schema_en }}
+                    {{form.eoi_decision_schema_cy(params={"classes": "welsh-field"}) }}
+                    {{form.contact_us_banner_en }}
+                    {{form.contact_us_banner_cy(params={"classes": "welsh-field"}) }}
+                    {{form.reference_contact_page_over_email}}
                     {{form.application_fields_download_available}}
                     {{form.display_logo_on_pdf_exports}}
                     {{form.mark_as_complete_enabled}}
                     {{form.is_expression_of_interest}}
                     {{form.has_feedback_survey}}
-                    {{form.has_section_feedback}}
-                    {{form.has_research_survey}}
                     {{form.is_feedback_survey_optional}}
-                    {{form.is_section_feedback_optional}}
+                    {{form.has_research_survey}}
                     {{form.is_research_survey_optional}}
                     {{form.eligibility_config}}
-                    {{form.eoi_decision_schema_en }}
-                    {{form.eoi_decision_schema_cy(params={"classes": "welsh-field"}) }}
                     <div class="govuk-button-group govuk-!-margin-top-6">
-                        {{ govukButton({
-                            "text": "Save and continue",
-                            "classes": "govuk-button",
-                            "name": "action",
-                            "value": "continue"
-                        }) }}
+                            {{ form.save_and_continue() }}
 
-                        {{ govukButton({
+                            {{ govukButton({
                             "text": "Cancel",
                             "classes": "govuk-button govuk-button--secondary",
-                            "href": url_for("index_bp.dashboard")
+                            "href": cancel_url
                         }) }}
                     </div>
-
                     <p class="govuk-body">
-                        {{ govukButton({
-                            "text": "Save and return to home",
-                            "classes": "govuk-button govuk-button--secondary",
-                            "name": "action",
-                            "value": "return_home"
-                        }) }}
+                        {{ form.save_and_return_home(params={'classes': 'govuk-button govuk-button--secondary'}) }}
                     </p>
                 </form>
             </fieldset>

--- a/app/blueprints/round/templates/round_details.html
+++ b/app/blueprints/round/templates/round_details.html
@@ -54,7 +54,7 @@
         "classes": "govuk-!-margin-bottom-9",
             "rows": [
                 {
-                    "key": {"text": "Application round"},
+                    "key": {"text": form.title_en.label},
                     "value": {"text": round.title_json["en"]},
                     "actions": {
                         "items": [
@@ -68,7 +68,7 @@
                     },
                 },
                 {
-                    "key": {"text": "Application round (Welsh)"},
+                    "key": {"text": form.title_en.label},
                     "value": {"text": round.title_json["cy"]},
                     "actions": {
                         "items": [
@@ -82,7 +82,7 @@
                     },
                 } if round.fund.welsh_available else {},
                 {
-                    "key": {"text": "Round short name"},
+                    "key": {"text": form.short_name.label},
                     "value": {"text": round.short_name},
                     "actions": {
                         "items": [
@@ -96,7 +96,7 @@
                     },
                 },
                 {
-                    "key": {"text": "Application round opens"},
+                    "key": {"text": form.opens.label},
                     "value": {"text": round.opens.strftime('%d %B %Y at %H:%M')},
                     "actions": {
                         "items": [
@@ -110,7 +110,7 @@
                     },
                 },
                 {
-                    "key": {"text": "Application round closes"},
+                    "key": {"text": form.deadline.label},
                     "value": {"text": round.deadline.strftime('%d %B %Y at %H:%M')},
                     "actions": {
                         "items": [
@@ -124,7 +124,7 @@
                     },
                 },
                 {
-                    "key": {"text": "Applicant reminder date"},
+                    "key": {"text": form.reminder_date.label},
                     "value": {"text": round.reminder_date.strftime('%d %B %Y at %H:%M')},
                     "actions": {
                         "items": [
@@ -138,7 +138,7 @@
                     },
                 },
                 {
-                    "key": {"text": "Assessment opens"},
+                    "key": {"text": form.assessment_start.label},
                     "value": {"text": round.assessment_start.strftime('%d %B %Y at %H:%M')},
                     "actions": {
                         "items": [
@@ -152,7 +152,7 @@
                     },
                 },
                 {
-                    "key": {"text": "Assessment closes"},
+                    "key": {"text": form.assessment_deadline.label},
                     "value": {"text": round.assessment_deadline.strftime('%d %B %Y at %H:%M')},
                     "actions": {
                         "items": [
@@ -222,7 +222,7 @@
                     },
                 },
                 {
-                    "key": {"text": "Grant team support hours"},
+                    "key": {"text": form.support_times.label},
                     "value": {"text": round.support_times},
                     "actions": {
                         "items": [
@@ -236,7 +236,7 @@
                     },
                 },
                 {
-                    "key": {"text": "Grant team support days"},
+                    "key": {"text": form.support_days.label},
                     "value": {"text": round.support_days},
                     "actions": {
                         "items": [
@@ -278,7 +278,7 @@
                     },
                 } if round.fund.welsh_available else {},
                 {
-                    "key": {"text": "Complete the application guidance"},
+                    "key": {"text": "Completing the application guidance"},
                     "value": {"text": round.application_guidance_json['en']},
                     "actions": {
                         "items": [
@@ -292,7 +292,7 @@
                     },
                 },
                 {
-                    "key": {"text": "Complete the application guidance (Welsh)"},
+                    "key": {"text": "Completing the application guidance (Welsh)"},
                     "value": {"text": round.application_guidance_json['cy']},
                     "actions": {
                         "items": [
@@ -320,7 +320,7 @@
                     },
                 },
                  {
-                    "key": {"text": "Prospectus link"},
+                    "key": {"text": form.prospectus_link.label},
                     "value": {"text": round.prospectus_link},
                     "actions": {
                         "items": [
@@ -334,7 +334,7 @@
                     },
                 },
                 {
-                    "key": {"text": "Privacy notice link"},
+                    "key": {"text": form.privacy_notice_link.label},
                     "value": {"text": round.privacy_notice_link},
                     "actions": {
                         "items": [
@@ -348,7 +348,7 @@
                     },
                 },
                 {
-                    "key": {"text": "Project name field ID"},
+                    "key": {"text": form.project_name_field_id.label},
                     "value": {"text": round.project_name_field_id},
                     "actions": {
                         "items": [
@@ -390,8 +390,8 @@
                     },
                 } if round.fund.welsh_available else {},
                 {
-                    "key": {"text": "Do you want to include the contact us page in applicant emails?"},
-                    "value": {"text": "Yes" if round.reference_contact_page_over_email == "true" else "No"},
+                    "key": {"text": form.reference_contact_page_over_email.label},
+                    "value": {"text": "Yes" if round.reference_contact_page_over_email else "No"},
                     "actions": {
                         "items": [
                             {
@@ -404,8 +404,8 @@
                     },
                 },
                 {
-                    "key": {"text": "Do you want to allow assessors to download application fields?"},
-                    "value": {"text": "Yes" if round.application_fields_download_available == "true" else "No"},
+                    "key": {"text": form.application_fields_download_available.label},
+                    "value": {"text": "Yes" if round.application_fields_download_available else "No"},
                     "actions": {
                         "items": [
                             {
@@ -418,8 +418,8 @@
                     },
                 },
                 {
-                    "key": {"text": "Do you want to have the MHCLG logo on PDFs?"},
-                    "value": {"text": "Yes" if round.display_logo_on_pdf_exports == "true" else "No"},
+                    "key": {"text": form.display_logo_on_pdf_exports.label},
+                    "value": {"text": "Yes" if round.display_logo_on_pdf_exports  else "No"},
                     "actions": {
                         "items": [
                             {
@@ -432,8 +432,8 @@
                     },
                 },
                 {
-                    "key": {"text": "Do you want applicants to mark sections as complete?"},
-                    "value": {"text": "Yes" if round.mark_as_complete_enabled == "true" else "No"},
+                    "key": {"text": form.mark_as_complete_enabled.label},
+                    "value": {"text": "Yes" if round.mark_as_complete_enabled else "No"},
                     "actions": {
                         "items": [
                             {
@@ -446,7 +446,7 @@
                     },
                 },
                 {
-                    "key": {"text": "Is this application round an expression of interest?"},
+                    "key": {"text": form.is_expression_of_interest.label},
                     "value": {"text": "Yes" if round.is_expression_of_interest == "true" else "No"},
                     "actions": {
                         "items": [
@@ -460,8 +460,8 @@
                     },
                 },
                 {
-                    "key": {"text": "Do you want to include a feedback survey?"},
-                    "value": {"text": "Yes" if round.feedback_survey_config["has_feedback_survey"]=="true" else "No"},
+                    "key": {"text": "form.has_feedback_survey.label"},
+                    "value": {"text": "Yes" if round.feedback_survey_config["has_feedback_survey"] else "No"},
                     "actions": {
                         "items": [
                             {
@@ -474,8 +474,8 @@
                     },
                 },
                 {
-                    "key": {"text": "Is the feedback survey optional?"},
-                    "value": {"text": "Yes" if round.feedback_survey_config["is_feedback_survey_optional"]=="true" else "No"},
+                    "key": {"text": form.is_feedback_survey_optional.label},
+                    "value": {"text": "Yes" if round.feedback_survey_config["is_feedback_survey_optional"] else "No"},
                     "actions": {
                         "items": [
                             {
@@ -488,8 +488,8 @@
                     },
                 },
                 {
-                    "key": {"text": "Do you want to include a research survey?"},
-                    "value": {"text": "Yes" if round.feedback_survey_config["has_research_survey"]=="true" else "No"},
+                    "key": {"text": form.has_research_survey.label},
+                    "value": {"text": "Yes" if round.feedback_survey_config["has_research_survey"] else "No"},
                     "actions": {
                         "items": [
                             {
@@ -502,8 +502,8 @@
                     },
                 },
                 {
-                    "key": {"text": "Is the research survey optional?"},
-                    "value": {"text": "Yes" if round.feedback_survey_config["is_research_survey_optional"]=="true" else "No"},
+                    "key": {"text": form.is_research_survey_optional.label},
+                    "value": {"text": "Yes" if round.feedback_survey_config["is_research_survey_optional"] else "No"},
                     "actions": {
                         "items": [
                             {
@@ -516,8 +516,8 @@
                     },
                 },
                 {
-                    "key": {"text": "Do applicants need to pass eligibility questions before applying?"},
-                    "value": {"text": "Yes" if round.eligibility_config["has_eligibility"] == "true" else "No"},
+                    "key": {"text": form.eligibility_config.label},
+                    "value": {"text": "Yes" if round.eligibility_config["has_eligibility"] else "No"},
                     "actions": {
                         "items": [
                             {


### PR DESCRIPTION
Ticket: https://mhclgdigital.atlassian.net/browse/FS-4970



### Change description
PR updating Application add and update api and templates

- [x ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
1. Create an application from Dashboard.
2. Back link should redirect to page form where it is initiated( works like browser backlink) --- select grant
3.Below actions can be tested on "Create a new application" page
  1. Save and Continue should navigate to 
      a. Design /Build Application page if it is initiated from Home with a success banner message.
      b. Application list page if it is initiated from Applications list page with success banner message.

   2. Save and return Home should navigate to
      a. home screen with a success banner message and link to design application inside banner as next step and link to the new application.
  3. Cancel should  navigate to
      a. Home page if initiated from home page
      b. Application list page if initiated from applications list.

Edit Application.
1. Go to Application list and click on an application 
2. Navigation:
Back link should redirect should navigate to Application details 
Save and Continue should navigate to Application details 
Save and return Home should navigate to home screen after updating application
Cancel should  navigate to Application details 

### Screenshots of UI changes (if applicable)
![image](https://github.com/user-attachments/assets/1c2225eb-44a9-424c-b471-ef52cdaaf803)

