### PR TITLE
Bugfix: fix application field labels and optional field validations

### DIFF
--- a/app/blueprints/round/forms.py
+++ b/app/blueprints/round/forms.py
@@ -5,7 +5,7 @@ from flask_wtf import FlaskForm
 from govuk_frontend_wtf.wtforms_widgets import GovRadioInput, GovSubmitInput, GovTextArea, GovTextInput
 from wtforms import HiddenField, RadioField, StringField, SubmitField, TextAreaField, URLField
 from wtforms.fields.datetime import DateTimeField
-from wtforms.validators import DataRequired, Length, ValidationError
+from wtforms.validators import DataRequired, Length, Optional, ValidationError
 
 from app.db.queries.round import get_round_by_short_name_and_fund_id
 from app.shared.validators import NoSpacesBetweenLetters
@@ -151,14 +151,14 @@ class RoundForm(FlaskForm):
     eoi_decision_schema_en = TextAreaField(
         "Expression of interest decision schema (optional)",
         widget=GovTextArea(),
-        validators=[validate_json_field],
+        validators=[Optional(), validate_json_field],
         description=JSON_FIELD_HINT,
     )
     eoi_decision_schema_cy = TextAreaField(
         "Expression of interest decision schema (Welsh) (optional)",
         widget=GovTextArea(),
         description=JSON_FIELD_HINT,
-        validators=[validate_json_field],
+        validators=[Optional(), validate_json_field],
     )
     contact_us_banner_en = TextAreaField(
         "Contact Us information (optional)",

--- a/app/blueprints/round/templates/round_details.html
+++ b/app/blueprints/round/templates/round_details.html
@@ -68,7 +68,7 @@
                     },
                 },
                 {
-                    "key": {"text": form.title_en.label},
+                    "key": {"text": form.title_cy.label},
                     "value": {"text": round.title_json["cy"]},
                     "actions": {
                         "items": [

--- a/tests/blueprints/round/test_routes.py
+++ b/tests/blueprints/round/test_routes.py
@@ -85,6 +85,30 @@ def test_create_round_with_existing_short_name(flask_test_client, seed_dynamic_d
 
 
 @pytest.mark.usefixtures("set_auth_cookie", "patch_validate_token_rs256_internal_user")
+def test_create_round_with_invalid_eoi_schema_json(flask_test_client, seed_dynamic_data):
+    """
+    Tests for rounds/create route verifies that the created round has the correct attributes
+    """
+    test_fund = seed_dynamic_data["funds"][0]
+    new_round_data = {
+        "fund_id": test_fund.fund_id,
+        "title_en": "New Round",
+        "short_name": "test123",
+        "save_and_return_home": True,
+        "eoi_decision_schema_en": "asdasd",
+        **round_data_info,
+    }
+
+    error_html = "Content is not valid JSON. Underlying error"
+    url = f"/rounds/create?fund_id={test_fund.fund_id}"
+
+    # Test works fine with first round
+    response = submit_form(flask_test_client, url, new_round_data)
+    assert response.status_code == 200
+    assert error_html in response.data.decode("utf-8"), "No errors found in response"
+
+
+@pytest.mark.usefixtures("set_auth_cookie", "patch_validate_token_rs256_internal_user")
 def test_update_existing_round(flask_test_client, seed_dynamic_data):
     """
     Tests that a round can be successfully updated using the /rounds/<round_id> route


### PR DESCRIPTION

### Change description
Fix the Application round label  and remove validations for optional EOI field.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
-
1. Create a application with empty EOI schema json , Application should be created
2. Create a application with a string (  Non Json) data , should render a form error "**There is a problem
[Content is not valid JSON. Underlying error:**"
3. Update a application with empty EOI schema json , Application should be updated
2. Update a application with a string (  Non Json) data , should render a form error "**There is a problem
[Content is not valid JSON. Underlying error:**"


<img width="1280" alt="image" src="https://github.com/user-attachments/assets/3b66be5d-6cf3-4c03-878f-091a0f6cb745" />
<img width="958" alt="image" src="https://github.com/user-attachments/assets/125cbb17-eab2-49f0-8762-db8f37fb2be1" />

