### PR TITLE
BAU: Build Application template preview open in new tab

### DIFF
--- a/app/blueprints/application/templates/build_application.html
+++ b/app/blueprints/application/templates/build_application.html
@@ -50,7 +50,7 @@
                             </span>
                             <span class="app-task-list__task-actions">
                                 <a class="govuk-link--no-visited-state" href="{{ url_for('application_bp.view_form_questions', round_id=round.round_id, section_id=section.section_id, form_id=form.form_id) }}">View questions</a>
-                                <a class="govuk-link--no-visited-state govuk-!-margin-left-2" href='{{ url_for("index_bp.preview_form", form_id=form.form_id) }}'>Preview</a>
+                                <a class="govuk-link--no-visited-state govuk-!-margin-left-2" target="_blank" href='{{ url_for("index_bp.preview_form", form_id=form.form_id) }}'>Preview</a>
                             </span>
                         </li>
                     {% endfor %}


### PR DESCRIPTION
### Change description
This makes consistent the 'preview template' behaviour on the template details page, and avoids users getting stuck on the form runner preview (which also includes a back link and top navigation that is specific to the runner/apply and not FAB).

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Go to 'Build application' of an application that has a section and a template added (or create one and add a section and template). Click 'Preview' on that template on the 'Build Application' page. It should open in a new browser tab.
