### PR TITLE
Point FAB UAT at test designer

### DIFF
--- a/copilot/fsd-fund-application-builder/manifest.yml
+++ b/copilot/fsd-fund-application-builder/manifest.yml
@@ -100,6 +100,8 @@ environments:
         path: /healthcheck
         port: 8080
   uat:
+    variables:
+      FORM_DESIGNER_EXTERNAL_HOST: "https://form-designer.test.access-funding.test.levellingup.gov.uk"
     count:
       range: 2-4
       cooldown:


### PR DESCRIPTION
We don't deploy form designer in the UAT environment :upside-down-face:

So we just get an error

<img width="714" alt="image" src="https://github.com/user-attachments/assets/41effd81-1391-4637-9766-c7a480afcc1e" />
