### PR TITLE
Remove service nav from form page

### DIFF
--- a/app/blueprints/template/templates/template.html
+++ b/app/blueprints/template/templates/template.html
@@ -1,6 +1,4 @@
 {% extends "base.html" %}
-{% set showNavigationBar = True %}
-{% set active_item_identifier = "templates" %}
 {% set back_link = True %}
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 {%- from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary -%}


### PR DESCRIPTION
We hide the service navigation on form pages, ostensibly so that users are less likely to accidentally navigate away. I think we just missed this one.