### PR TITLE
fix form template table bug

### DIFF
--- a/app/db/queries/application.py
+++ b/app/db/queries/application.py
@@ -21,7 +21,7 @@ def get_all_template_forms() -> list[Form]:
     return db.session.query(Form).where(Form.is_template == True).order_by(Form.template_name).all()  # noqa:E712
 
 
-def get_paginated_forms(page: int, items_per_page: int = 5) -> Pagination:
+def get_paginated_forms(page: int, items_per_page: int = 20) -> Pagination:
     stmt = select(Form).where(Form.is_template == True).order_by(cast(Form.template_name, String))
     return db.paginate(stmt, page=page, per_page=items_per_page)
 


### PR DESCRIPTION
fix form template table bug and here we have added accidentally default number of items pages to 5 and it should be 20 in the template page 
