### PR TITLE
FS-5033 - Templates table - replace "Edit details" buttons with "Preview in a new tab"

### DIFF
--- a/app/blueprints/template/templates/view_all_templates.html
+++ b/app/blueprints/template/templates/view_all_templates.html
@@ -61,16 +61,17 @@
            href='{{ url_for('template_bp.template_details', form_id=form.form_id) }}'>{{ form.template_name }}</a>
         {% endset %}
 
-        {% set form_edit_link %}
+        {% set form_preview_link %}
         <a class='govuk-link govuk-link--no-visited-state'
-           href='{{ url_for('template_bp.edit_template', form_id=form.form_id, actions='template_table') }}'>
-            Edit details</a>
+        target="_blank"
+        href='{{ url_for("index_bp.preview_form", form_id=form.form_id) }}'>
+            Preview in a new tab</a>
         {% endset %}
 
         {% set table_rows.items = table_rows.items + [[
             {"html": form_link},
             {"classes": "govuk-!-width-one-third", "text": form.name_in_apply_json["en"]},
-            {"classes": "govuk-!-text-align-right fab-nowrap","html": form_edit_link,}
+            {"classes": "govuk-!-text-align-right fab-nowrap","html": form_preview_link,}
                             ]] %}
         {% endfor %}
 

--- a/tests/unit/blueprints/template/test_routes.py
+++ b/tests/unit/blueprints/template/test_routes.py
@@ -53,7 +53,7 @@ def test_generalized_table_template_with_existing_templates(flask_test_client):
     assert "Apply for funding to save an asset in your community" in html, (
         "Tasklist name and table component is missing"
     )
-    assert "Edit details" in html, "Edit action is missing"
+    assert "Preview in a new tab" in html, "Preview action is missing"
 
 
 @pytest.mark.usefixtures("set_auth_cookie", "patch_validate_token_rs256_internal_user", "seed_dynamic_data")


### PR DESCRIPTION
### Ticket

[Button placement, UI clarity and navigation updates](https://mhclgdigital.atlassian.net/browse/FS-5033) (this PR only covers the second part of the ticket, around the "Templates" page)

### Summary of changes made

- Replacing "Edit details" button with "Preview in a new tab"

### Screenshot of UI change

![image](https://github.com/user-attachments/assets/98e9708e-8173-4b81-8dce-ff26447aec72)