### PR TITLE
Adding group auth to FAB

### DIFF
--- a/app/create_app.py
+++ b/app/create_app.py
@@ -28,7 +28,9 @@ def protect_private_routes(flask_app: Flask) -> Flask:
         if endpoint in PUBLIC_ROUTES:
             continue
         flask_app.view_functions[endpoint] = login_required(
-            check_internal_user(view_func), return_app=SupportedApp.FUND_APPLICATION_BUILDER
+            check_internal_user(view_func),
+            roles_required=["FSD_ADMIN"],
+            return_app=SupportedApp.FUND_APPLICATION_BUILDER,
         )
     return flask_app
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -137,7 +137,7 @@ def patch_validate_token_rs256_internal_user():
     with patch("fsd_utils.authentication.decorators.validate_token_rs256") as mock_validate_token_rs256:
         mock_validate_token_rs256.return_value = {
             "accountId": "test-account-id",
-            "roles": [],
+            "roles": ["FSD_ADMIN"],
             "email": "test@communities.gov.uk",
         }
         yield mock_validate_token_rs256
@@ -149,7 +149,7 @@ def patch_validate_token_rs256_external_user():
     with patch("fsd_utils.authentication.decorators.validate_token_rs256") as mock_validate_token_rs256:
         mock_validate_token_rs256.return_value = {
             "accountId": "test-account-id",
-            "roles": [],
+            "roles": ["FSD_ADMIN"],
             "email": "test@gmail.com",
         }
         yield mock_validate_token_rs256


### PR DESCRIPTION
Users must be a member of the "FSD_ADMIN" group in Azure AD to authenticate, as per TDA requirements.