### PR TITLE
FS-5033 - Re-adding missing action buttons on "Create section" page

### DIFF
--- a/app/blueprints/application/templates/section.html
+++ b/app/blueprints/application/templates/section.html
@@ -89,6 +89,15 @@
                     </div>
                 </div>
             </div>
+        {% else %}
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <div class="govuk-button-group">
+                        {{ form.save_section() }}
+                        <a href="{{ url_for('application_bp.build_application', round_id=round_id) }}" class="govuk-button govuk-button--secondary">Cancel</a>
+                    </div>
+                </div>
+            </div>
         {% endif %}
     </form>
 


### PR DESCRIPTION
### Ticket

[Button placement, UI clarity and navigation updates](https://mhclgdigital.atlassian.net/browse/FS-5033)

### Description

The previous [PR for modifying the "Update section" page](https://github.com/communitiesuk/funding-service-design-fund-application-builder/pull/297) had an unintended side-effect - it removed the "Save" button from the "Create section" page, which is rendered from the same Jinja2 template. See screenshot below:

![image](https://github.com/user-attachments/assets/347fdfe4-9437-4f6c-9b13-12a2607d5d8f)

This PR addresses that. It also takes the liberty of going one step further, and replacing the old "Save" button with a "Save and continue" button, with a "Cancel" button added for good measure, for consistency with the updates to the "Edit section" page. @mikaelmetthey - if you would prefer to revert to simply having a "Save" button, then that's also fine - I'll make that change.

### Screenshot of UI change

![image](https://github.com/user-attachments/assets/05976031-acd8-454c-a916-fc8a10db5d57)
