### PR TITLE
FS-5044 - Add role-based auth to FAB

### DIFF
--- a/app/create_app.py
+++ b/app/create_app.py
@@ -28,7 +28,9 @@ def protect_private_routes(flask_app: Flask) -> Flask:
         if endpoint in PUBLIC_ROUTES:
             continue
         flask_app.view_functions[endpoint] = login_required(
-            check_internal_user(view_func), return_app=SupportedApp.FUND_APPLICATION_BUILDER
+            check_internal_user(view_func),
+            roles_required=["FSD_ADMIN"],
+            return_app=SupportedApp.FUND_APPLICATION_BUILDER,
         )
     return flask_app
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -137,7 +137,7 @@ def patch_validate_token_rs256_internal_user():
     with patch("fsd_utils.authentication.decorators.validate_token_rs256") as mock_validate_token_rs256:
         mock_validate_token_rs256.return_value = {
             "accountId": "test-account-id",
-            "roles": [],
+            "roles": ["FSD_ADMIN"],
             "email": "test@communities.gov.uk",
         }
         yield mock_validate_token_rs256
@@ -149,7 +149,7 @@ def patch_validate_token_rs256_external_user():
     with patch("fsd_utils.authentication.decorators.validate_token_rs256") as mock_validate_token_rs256:
         mock_validate_token_rs256.return_value = {
             "accountId": "test-account-id",
-            "roles": [],
+            "roles": ["FSD_ADMIN"],
             "email": "test@gmail.com",
         }
         yield mock_validate_token_rs256


### PR DESCRIPTION
### Ticket

[Add role-based auth to FAB](https://mhclgdigital.atlassian.net/browse/FS-5044)

### Description

Users must be a member of the "FSD_ADMIN" group in Azure AD to authenticate for FAB, as per TDA requirements.

### How to test

*Pre-requisites*
- Get the Funding Service repos cloned locally (see [Docker Runner](https://github.com/communitiesuk/funding-service-design-docker-runner))
- Checkout this branch in FAB repo

*Auth success*
- Request to myself or Gideon that you are added to the "FSD_ADMIN" group on the test Azure AD tenant
- Spin up database, FAB and Pre-Award containers locally
- Go to https://fund-application-builder.levellingup.gov.localhost:3011/ in your browser (preferably in an incognito window to avoid any previous auth state)
- Sign in with your Microsoft credentials
- Confirm that you end up landing on the FAB home page, with "Fund application builder" in the black banner at the top

*Auth failure*
- Replace "FSD_ADMIN" with some other random string in `create_app.py`, to ensure that you do not have the correct role
- Spin up database, FAB and Pre-Award containers locally (see [Docker Runner](https://github.com/communitiesuk/funding-service-design-docker-runner))
- Go to https://fund-application-builder.levellingup.gov.localhost:3011/ in your browser (preferably in an incognito window to avoid any previous auth state)
- Sign in with your Microsoft credentials
- Confirm that you end up landing on a page in the Authenticator frontend with content that includes "Contact the [Forms team on Slack](https://communities-govuk.slack.com/archives/C08CK8SUUBU) at #funding-service-forms-support to request access."