### PR TITLE
FS-5033 - "Build application" page design changes

### DIFF
--- a/app/blueprints/application/templates/build_application.html
+++ b/app/blueprints/application/templates/build_application.html
@@ -14,31 +14,42 @@
     </div>
     <ul class="app-task-list__items">
         {% for section in round.sections %}
-        <li class="">
+        <li class="task-list__new-design govuk-!-margin-bottom-2">
                 <span class="app-task-list__task-name">
                     <h3 class="govuk-heading-m">{{ section.index }}. {{ section.name_in_apply_json["en"] }}</h3>
                 </span>
                 <span class="app-task-list__task-actions">
-                    <a class="govuk-link--no-visited-state" href='{{ url_for("application_bp.section", round_id=round.round_id, section_id=section.section_id) }}'>Edit</a>
-                    <a class="govuk-link--no-visited-state govuk-!-margin-left-2" href='{{ url_for("application_bp.delete_section",round_id=round.round_id, section_id=section.section_id) }}'>Remove</a>
-                    {% if section.index > 1 %}
-                        <a class="govuk-link--no-visited-state govuk-!-margin-left-2" href='{{ url_for("application_bp.move_section_up_route",round_id=round.round_id, section_id=section.section_id) }}'>Move up</a>
+                    {% if section.index == round.sections | length %}
+                        <span class="govuk-!-font-size-19 govuk-!-margin-right-2 disabled-link">Down</span>
+                    {% else %}
+                        <a class="govuk-!-font-size-19 govuk-!-margin-right-2 govuk-link--no-visited-state"
+                           href='{{ url_for("application_bp.move_section_down_route",round_id=round.round_id, section_id=section.section_id) }}'>Down</a>
                     {% endif %}
-                    {% if section.index < round.sections | length %}
-                        <a class="govuk-link--no-visited-state govuk-!-margin-left-2" href='{{ url_for("application_bp.move_section_down_route",round_id=round.round_id, section_id=section.section_id) }}'> Move down</a>
+                    {% if section.index == 1 %}
+                        <span class="govuk-!-font-size-19 govuk-!-margin-right-2 disabled-link">Up</span>
+                    {% else %}
+                        <a class="govuk-!-font-size-19 govuk-!-margin-right-2 govuk-link--no-visited-state"
+                           href='{{ url_for("application_bp.move_section_up_route",round_id=round.round_id, section_id=section.section_id) }}'>Up</a>
                     {% endif %}
+                    <a class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0"
+                       href='{{ url_for("application_bp.section", round_id=round.round_id, section_id=section.section_id) }}'>Edit</a>
                 </span>
+        </li>
+        <li>
                 <ul class="app-task-list__items">
                     {% for form in section.forms %}
                         <li class="app-task-list__item task-list__new-design">
                             <span class="app-task-list__task-name">
                                 <h3 class="govuk-body">
-                                    {{ form.name_in_apply_json["en"] }}
+                                    <a class="govuk-link govuk-link--no-visited-state"
+                                       target="_blank"
+                                       href='{{ url_for("index_bp.preview_form", form_id=form.form_id) }}'>
+                                        {{ form.name_in_apply_json["en"] }} (previews in a new tab)
+                                    </a>
                                 </h3>
                             </span>
                             <span class="app-task-list__task-actions">
-                                <a class="govuk-link--no-visited-state" href="{{ url_for('application_bp.view_form_questions', round_id=round.round_id, section_id=section.section_id, form_id=form.form_id) }}">View questions</a>
-                                <a class="govuk-link--no-visited-state govuk-!-margin-left-2" target="_blank" href='{{ url_for("index_bp.preview_form", form_id=form.form_id) }}'>Preview</a>
+                                <a class="govuk-link--no-visited-state govuk-!-font-size-19" href="{{ url_for('application_bp.view_form_questions', round_id=round.round_id, section_id=section.section_id, form_id=form.form_id) }}">View questions</a>
                             </span>
                         </li>
                     {% endfor %}

--- a/tests/unit/blueprints/application/test_routes.py
+++ b/tests/unit/blueprints/application/test_routes.py
@@ -82,7 +82,7 @@ def test_update_section_name(flask_test_client, seed_dynamic_data):
     data = {"name_in_apply_en": "section 1", "save_section": True}
     response = submit_form(flask_test_client, url, data, follow_redirects=True)
     soup = BeautifulSoup(response.data, "html.parser")
-    edit_section_link = soup.find("a", class_="govuk-link--no-visited-state", string="Edit").get("href")
+    edit_section_link = soup.find("a", class_="govuk-button--secondary", string="Edit").get("href")
     data = {
         "name_in_apply_en": "section updated",
         "save_section": True,
@@ -103,7 +103,7 @@ def test_update_section_empty_template_section_name(flask_test_client, seed_dyna
     data = {"name_in_apply_en": "section 1", "save_section": True}
     response = submit_form(flask_test_client, url, data, follow_redirects=True)
     soup = BeautifulSoup(response.data, "html.parser")
-    edit_section_link = soup.find("a", class_="govuk-link--no-visited-state", string="Edit").get("href")
+    edit_section_link = soup.find("a", class_="govuk-button--secondary", string="Edit").get("href")
     data = {"name_in_apply_en": "", "add_form": True, "section_id": edit_section_link.split("/")[-1], "template_id": ""}
 
     response = submit_form(flask_test_client, edit_section_link, data, follow_redirects=False)
@@ -134,7 +134,7 @@ def test_update_template_form(flask_test_client, seed_dynamic_data):
     data = {"name_in_apply_en": "section 1", "save_section": True}
     response = submit_form(flask_test_client, url, data, follow_redirects=True)
     soup = BeautifulSoup(response.data, "html.parser")
-    edit_section_link = soup.find("a", class_="govuk-link--no-visited-state", string="Edit").get("href")
+    edit_section_link = soup.find("a", class_="govuk-button--secondary", string="Edit").get("href")
     data = {
         "name_in_apply_en": "",
         "add_form": True,


### PR DESCRIPTION
### Ticket

[Button placement, UI clarity and navigation updates](https://mhclgdigital.atlassian.net/browse/FS-5033) (this PR only covers the third part of the ticket, around the "Build application" page)

### Description

- Replaced section action links with "Down" / "Up" links and "Edit" button, matching section.html styling
- Made task names clickable links opening previews in new tabs, removing separate "Preview" link

### Screenshot of UI change

![image](https://github.com/user-attachments/assets/27f15a79-7b9f-4439-b0bb-f86d29828109)
