### PR TITLE
FS-5033 - Reset "Add a task" dropdown to "Select a template" after adding a task to a section

### DIFF
--- a/app/blueprints/application/routes.py
+++ b/app/blueprints/application/routes.py
@@ -190,6 +190,7 @@ def section(round_id, section_id=None):
         section = get_section_by_id(section_id=section_id)
         new_section_index = max(len(section.forms) + 1, 1)
         clone_single_form(form_id=form.template_id.data, new_section_id=section_id, section_index=new_section_index)
+        form.template_id.data = ""  # Reset the template_id field to default after adding
 
     if section_id:
         existing_section = get_section_by_id(section_id)


### PR DESCRIPTION
### Ticket

[Button placement, UI clarity and navigation updates](https://mhclgdigital.atlassian.net/browse/FS-5033) (this PR only covers the third part of the ticket, around the "Build application" page)

### Description

This is a minor tweak to [an already-merged PR](https://github.com/communitiesuk/funding-service-design-fund-application-builder/pull/308) in response to [QA review](https://mhclgdigital.atlassian.net/browse/FS-5033?focusedCommentId=655907). The only change here is:

- Reset "Add a task" dropdown to "Select a template" after adding a task to a section