### PR TITLE
FSPT-228: Move test to communities domain name

### DIFF
--- a/copilot/fsd-fund-application-builder/manifest.yml
+++ b/copilot/fsd-fund-application-builder/manifest.yml
@@ -112,7 +112,7 @@ environments:
         port: 8080
   uat:
     variables:
-      FORM_DESIGNER_EXTERNAL_HOST: "https://form-designer.test.access-funding.test.levellingup.gov.uk"
+      FORM_DESIGNER_EXTERNAL_HOST: "https://form-designer.access-funding.test.communities.gov.uk"
     count:
       range: 2-4
       cooldown:

--- a/copilot/fsd-fund-application-builder/manifest.yml
+++ b/copilot/fsd-fund-application-builder/manifest.yml
@@ -86,6 +86,11 @@ environments:
         path: /healthcheck
         port: 8080
   test:
+    variables:
+      FUND_APPLICATION_BUILDER_HOST: "https://fund-application-builder.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
+      AUTHENTICATOR_HOST: "https://account.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
+      FORM_RUNNER_EXTERNAL_HOST: "https://application-questions.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
+      FORM_DESIGNER_EXTERNAL_HOST: "https://form-designer.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
     count:
       spot: 2
     sidecars:
@@ -100,6 +105,7 @@ environments:
           BASIC_AUTH_USERNAME: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_USERNAME
           BASIC_AUTH_PASSWORD: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_PASSWORD
     http:
+      alias: ['fund-application-builder.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk', 'fund-application-builder.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk']
       target_container: nginx
       healthcheck:
         path: /healthcheck

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -50,8 +50,8 @@ def domains(request: pytest.FixtureRequest, get_e2e_params) -> FabDomains:
             )
         case "test":
             return FabDomains(
-                fab_url="https://fund-application-builder.test.access-funding.test.levellingup.gov.uk",
-                cookie_domain=".test.access-funding.test.levellingup.gov.uk",
+                fab_url="https://fund-application-builder.access-funding.test.communities.gov.uk",
+                cookie_domain=".access-funding.test.communities.gov.uk",
             )
         case _:
             raise ValueError(f"not configured for {e2e_env}")


### PR DESCRIPTION

### Change description
Config changes to move test to communities domain name

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
After deployment service should be available on the test.communities.gov.uk domain name


### Screenshots of UI changes (if applicable)
