### PR TITLE
Fixes the behaviour of the 'Cancel' button on the 'Select Fund' page

### DIFF
--- a/app/blueprints/application/routes.py
+++ b/app/blueprints/application/routes.py
@@ -68,7 +68,7 @@ def select_fund():
         return redirect(url_for("application_bp.select_application", fund_id=form.fund_id.data))
     select_items = [{"value": value, "text": text} for value, text in choices]
     return render_template(
-        "select_fund.html", form=form, select_items=select_items, back_link=url_for("index_bp.dashboard")
+        "select_fund.html", form=form, select_items=select_items, cancel_url=url_for(INDEX_BP_DASHBOARD)
     )
 
 

--- a/app/blueprints/round/routes.py
+++ b/app/blueprints/round/routes.py
@@ -67,7 +67,11 @@ def select_fund():
     if form.fund_id.errors:
         error = {"titleText": "There is a problem", "errorList": [{"text": form.fund_id.errors[0], "href": "#fund_id"}]}
     select_items = [{"value": value, "text": text} for value, text in choices]
-    return render_template("select_fund.html", form=form, error=error, select_items=select_items)
+
+    action = request.args.get("action")
+    cancel_url = _create_round_get_previous_url(action)
+
+    return render_template("select_fund.html", form=form, error=error, select_items=select_items, cancel_url=cancel_url)
 
 
 def _create_round_get_previous_url(action):

--- a/app/templates/select_fund.html
+++ b/app/templates/select_fund.html
@@ -33,7 +33,7 @@
                     }) }}
                     {{ govukButton({
                       "text": "Cancel",
-                      "href": url_for("index_bp.dashboard"),
+                      "href": cancel_url,
                       "classes": "govuk-button--secondary"
                     }) }}
                 </div>


### PR DESCRIPTION
### Description

Fixes the behaviour of the 'Cancel' button on the 'Select Fund' page

E.g., if we come from 'Applications table' page, we want 'Cancel' to send us back there (as per request from designers).

### How to test

- Checkout this branch and spin up FAB locally
- Navigate to the [Applications page](https://fund-application-builder.levellingup.gov.localhost:3011/rounds/) and click "Create new application"
- Click "Cancel" on the [Select Fund page](https://fund-application-builder.levellingup.gov.localhost:3011/rounds/select-grant?action=applications_table) and verify it returns to the Applications page
- Navigate to the [Dashboard](https://fund-application-builder.levellingup.gov.localhost:3011/dashboard) and click on "2. Set up a new application"
- Click "Cancel" on the [Select Fund page](https://fund-application-builder.levellingup.gov.localhost:3011/rounds/select-grant?action=return_home) and verify it returns to the Dashboard



