### PR TITLE
FS-5030: Implementing e2e test running after deploying to dev and test environments

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -5,14 +5,18 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description:  Which AWS Account to use
+        description: Which AWS Account to use
         type: choice
         required: true
         options:
-        - dev
-        - test
-        - uat
-
+          - dev
+          - test
+          - uat
+      run_e2e_tests:
+        required: false
+        default: true
+        type: boolean
+        description: Run e2e tests after deployment
   push:
 
 jobs:
@@ -21,7 +25,7 @@ jobs:
     with:
       environment: ${{ inputs.environment }}
 
-  pre_deploy_tests:
+  unit_tests:
     uses: communitiesuk/funding-service-design-workflows/.github/workflows/pre-deploy.yml@main
     with:
       postgres_unit_testing: true
@@ -39,7 +43,7 @@ jobs:
       assets_required: true
 
   dev_deploy:
-    needs: [ pre_deploy_tests, paketo_build, setup ]
+    needs: [ unit_tests, paketo_build, setup ]
     if: ${{ contains(fromJSON(needs.setup.outputs.jobs_to_run), 'dev') }}
     uses: communitiesuk/funding-service-design-workflows/.github/workflows/standard-deploy.yml@main
     secrets:
@@ -51,24 +55,18 @@ jobs:
       image_location: ${{ needs.paketo_build.outputs.image_location }}
       notify_slack: false
 
-  # post_dev_deploy_tests:
-  #   needs: dev_deploy
-  #   concurrency:
-  #     group: 'fsd-preaward-dev'
-  #     cancel-in-progress: false
-  #   secrets:
-  #     FSD_GH_APP_ID: ${{ secrets.FSD_GH_APP_ID }}
-  #     FSD_GH_APP_KEY: ${{ secrets.FSD_GH_APP_KEY }}
-  #   uses: communitiesuk/funding-service-design-workflows/.github/workflows/post-deploy.yml@main
-  #   with:
-  #     run_performance_tests: ${{ inputs.run_performance_tests || true }}
-  #     run_e2e_tests_assessment: ${{ inputs.run_e2e_tests_assessment || false }}
-  #     run_e2e_tests_application: ${{ inputs.run_e2e_tests_application || false }}
-  #     app_name: fund-application-builder
-  #     environment: dev
+  dev_e2e_test:
+    # Do not run these against the prod environment without addressing the auth/JWT self-signing done by e2e tests.
+    if: ${{ contains(fromJSON(needs.setup.outputs.jobs_to_run), 'dev') && inputs.run_e2e_tests == true }}
+    name: Run E2E Dev
+    needs: [ dev_deploy ]
+    uses: ./.github/workflows/test_e2e_aws.yml
+    with:
+      copilot_environment: 'dev'
+    secrets: inherit # pragma: allowlist secret
 
   test_deploy:
-    needs: [ dev_deploy, paketo_build, setup ]
+    needs: [ dev_deploy, dev_e2e_test, paketo_build, setup ]
     if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'test') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') )}}
     uses: communitiesuk/funding-service-design-workflows/.github/workflows/standard-deploy.yml@main
     secrets:
@@ -82,25 +80,18 @@ jobs:
       image_location: ${{ needs.paketo_build.outputs.image_location }}
       notify_slack: true
 
-  # post_test_deploy_tests:
-  #   needs: test_deploy
-  #   if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'test') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') )}}
-  #   concurrency:
-  #     group: 'fsd-preaward-test'
-  #     cancel-in-progress: false
-  #   secrets:
-  #     FSD_GH_APP_ID: ${{ secrets.FSD_GH_APP_ID }}
-  #     FSD_GH_APP_KEY: ${{ secrets.FSD_GH_APP_KEY }}
-  #   uses: communitiesuk/funding-service-design-workflows/.github/workflows/post-deploy.yml@main
-  #   with:
-  #     run_performance_tests: ${{ inputs.run_performance_tests || false }}
-  #     run_e2e_tests_assessment: ${{ inputs.run_e2e_tests_assessment || false }}
-  #     run_e2e_tests_application: ${{ inputs.run_e2e_tests_application || true }}
-  #     app_name: fund-application-builder
-  #     environment: test
+  test_e2e_test:
+    # Do not run these against the prod environment without addressing the auth/JWT self-signing done by e2e tests.
+    if: ${{ contains(fromJSON(needs.setup.outputs.jobs_to_run), 'test') && inputs.run_e2e_tests == true }}
+    name: Run E2E Test
+    needs: [ dev_deploy ]
+    uses: ./.github/workflows/test_e2e_aws.yml
+    with:
+      copilot_environment: 'test'
+    secrets: inherit # pragma: allowlist secret
 
   uat_deploy:
-    needs: [ dev_deploy, test_deploy, paketo_build, setup ]
+    needs: [ dev_deploy, test_e2e_test, test_deploy, paketo_build, setup ]
     if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'uat') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') )}}
     uses: communitiesuk/funding-service-design-workflows/.github/workflows/standard-deploy.yml@main
     secrets:
@@ -115,32 +106,3 @@ jobs:
       image_location: ${{ needs.paketo_build.outputs.image_location }}
       notify_slack: true
       notify_slack_on_deployment: true
-
-  # post_uat_deploy_tests:
-  #   needs: uat_deploy
-  #   if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'uat') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') )}}
-  #   concurrency:
-  #     group: 'fsd-preaward-uat'
-  #     cancel-in-progress: false
-  #   secrets:
-  #     FSD_GH_APP_ID: ${{ secrets.FSD_GH_APP_ID }}
-  #     FSD_GH_APP_KEY: ${{ secrets.FSD_GH_APP_KEY }}
-  #   uses: communitiesuk/funding-service-design-workflows/.github/workflows/post-deploy.yml@main
-  #   with:
-  #     run_performance_tests: ${{ inputs.run_performance_tests || false }}
-  #     run_e2e_tests_assessment: ${{ inputs.run_e2e_tests_assessment || false }}
-  #     run_e2e_tests_application: ${{ inputs.run_e2e_tests_application || true }}
-  #     app_name: fund-application-builder
-  #     environment: uat
-
-  # prod_deploy:
-  #   needs: [ dev_deploy, post_dev_deploy_tests, test_deploy, post_test_deploy_tests, uat_deploy, post_uat_deploy_tests, paketo_build, setup ]
-  #   if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'prod') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') )}}
-  #   uses: communitiesuk/funding-service-design-workflows/.github/workflows/standard-deploy.yml@main
-  #   secrets:
-  #     AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
-  #   with:
-  #     environment: prod
-  #     app_name: fund-application-builder
-  #     run_db_migrations: true
-  #     image_location: ${{ needs.paketo_build.outputs.image_location }}

--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -57,12 +57,12 @@ jobs:
 
   dev_e2e_test:
     # Do not run these against the prod environment without addressing the auth/JWT self-signing done by e2e tests.
-    if: ${{ contains(fromJSON(needs.setup.outputs.jobs_to_run), 'dev') && inputs.run_e2e_tests == true }}
+    if: ${{ contains(fromJSON(needs.setup.outputs.jobs_to_run), 'dev') && ((github.event_name == 'push' && true) || inputs.run_e2e_tests == true) }}
     name: Run E2E Dev
     needs: [ dev_deploy ]
     uses: ./.github/workflows/test_e2e_aws.yml
     with:
-      copilot_environment: 'dev'
+      environment: 'dev'
     secrets: inherit # pragma: allowlist secret
 
   test_deploy:
@@ -82,16 +82,16 @@ jobs:
 
   test_e2e_test:
     # Do not run these against the prod environment without addressing the auth/JWT self-signing done by e2e tests.
-    if: ${{ contains(fromJSON(needs.setup.outputs.jobs_to_run), 'test') && inputs.run_e2e_tests == true }}
+    if: ${{ contains(fromJSON(needs.setup.outputs.jobs_to_run), 'test') && ((github.event_name == 'push' && true) || inputs.run_e2e_tests == true) }}
     name: Run E2E Test
-    needs: [ dev_deploy ]
+    needs: [ test_deploy ]
     uses: ./.github/workflows/test_e2e_aws.yml
     with:
-      copilot_environment: 'test'
+      environment: 'test'
     secrets: inherit # pragma: allowlist secret
 
   uat_deploy:
-    needs: [ dev_deploy, test_e2e_test, test_deploy, paketo_build, setup ]
+    needs: [ test_e2e_test, test_deploy, paketo_build, setup ]
     if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'uat') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') )}}
     uses: communitiesuk/funding-service-design-workflows/.github/workflows/standard-deploy.yml@main
     secrets:

--- a/.github/workflows/test_e2e_aws.yml
+++ b/.github/workflows/test_e2e_aws.yml
@@ -2,14 +2,14 @@ name: Run e2e tests
 on:
   workflow_call:
     inputs:
-      copilot_environment:
-        description: "Copilot environment to deploy to"
+      environment:
+        description: "E2E Env Selector"
         type: string
         default: dev
   workflow_dispatch:
     inputs:
-      copilot_environment:
-        description: "Copilot environment to deploy to"
+      environment:
+        description: "E2E Env Selector"
         type: choice
         options:
           - dev
@@ -23,23 +23,27 @@ jobs:
       id-token: write # This is required for requesting the JWT
       contents: read  # This is required for actions/checkout
     runs-on: ubuntu-latest
-    environment: ${{ inputs.copilot_environment }}
+    container: mcr.microsoft.com/playwright:v1.47.0-noble
+    environment: ${{ inputs.environment }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout e2e tests
+        uses: actions/checkout@v4
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231 # v5
+        uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-          github-token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-      - name: Install playwright browsers
-        run: uv run --frozen playwright install --with-deps
-      - name: Setup AWS credentials
-        uses: communitiesuk/funding-service-design-workflows/.github/actions/copilot_setup@main
+      - name: Get current date
+        shell: bash
+        id: currentdatetime
+        run: echo "datetime=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          copilot_environment: ${{ inputs.copilot_environment }}
-          AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/GithubCopilotDeploy
+          role-session-name: COPILOT_${{ inputs.environment }}_FAB_${{ steps.currentdatetime.outputs.datetime }}
+          aws-region: eu-west-2
       - name: Run tests
-        run: uv run --frozen pytest --e2e --e2e-env ${{ inputs.copilot_environment }}
+        run: uv run --frozen pytest --e2e --e2e-env ${{ inputs.environment }}
         env:
           E2E_DEVTEST_BASIC_AUTH_USERNAME: ${{ secrets.E2E_DEVTEST_BASIC_AUTH_USERNAME }}
-          E2E_DEVTEST_BASIC_AUTH_PASSWORD: ${{ secrets.E2E_DEVTEST_BASIC_AUTH_USERNAME }}
+          E2E_DEVTEST_BASIC_AUTH_PASSWORD: ${{ secrets.E2E_DEVTEST_BASIC_AUTH_PASSWORD }}

--- a/.github/workflows/test_e2e_aws.yml
+++ b/.github/workflows/test_e2e_aws.yml
@@ -1,0 +1,45 @@
+name: Run e2e tests
+on:
+  workflow_call:
+    inputs:
+      copilot_environment:
+        description: "Copilot environment to deploy to"
+        type: string
+        default: dev
+  workflow_dispatch:
+    inputs:
+      copilot_environment:
+        description: "Copilot environment to deploy to"
+        type: choice
+        options:
+          - dev
+          - test
+        default: dev
+
+jobs:
+  run_tests:
+    name: e2e tests
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read  # This is required for actions/checkout
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.copilot_environment }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231 # v5
+        with:
+          enable-cache: true
+          github-token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+      - name: Install playwright browsers
+        run: uv run --frozen playwright install --with-deps
+      - name: Setup AWS credentials
+        uses: communitiesuk/funding-service-design-workflows/.github/actions/copilot_setup@main
+        with:
+          copilot_environment: ${{ inputs.copilot_environment }}
+          AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
+      - name: Run tests
+        run: uv run --frozen pytest --e2e --e2e-env ${{ inputs.copilot_environment }}
+        env:
+          E2E_DEVTEST_BASIC_AUTH_USERNAME: ${{ secrets.E2E_DEVTEST_BASIC_AUTH_USERNAME }}
+          E2E_DEVTEST_BASIC_AUTH_PASSWORD: ${{ secrets.E2E_DEVTEST_BASIC_AUTH_USERNAME }}


### PR DESCRIPTION
**Ticket: https://mhclgdigital.atlassian.net/browse/FS-5030**


### Change description
Implementing e2e test running after deploying to dev and test environments

After having the discussion with @wjrm500 we have decided to brake this FS-5030 into two sub sections and it is already mentioned in this [comment](https://mhclgdigital.atlassian.net/browse/FS-5030?focusedCommentId=658274)

Once changes are merged into main and docker images is deployed to dev then after that if the e2e run is enabled then this changes will handle the e2e run process against the dev environment & also same for the test once changes are deployed to test it will run the e2e against test environment 

Following is one of the testing done by my self : https://github.com/communitiesuk/funding-service-design-fund-application-builder/actions/runs/13763808399 
