### PR TITLE
FS-5031 - Fix template details back link after form is previewed

### DIFF
--- a/app/shared/page_tracker.py
+++ b/app/shared/page_tracker.py
@@ -2,7 +2,7 @@ from flask import request, session
 
 from app.blueprints.application.routes import application_bp
 from app.blueprints.fund.routes import fund_bp, view_all_funds
-from app.blueprints.index.routes import dashboard, go_back, index_bp
+from app.blueprints.index.routes import dashboard, go_back, index_bp, preview_form
 from app.blueprints.round.routes import round_bp, view_all_rounds
 from app.blueprints.template.routes import template_bp, view_templates
 
@@ -10,7 +10,10 @@ from app.blueprints.template.routes import template_bp, view_templates
 class PageTracker:
     def __init__(self):
         self.tracked_blueprints = {template_bp.name, index_bp.name, application_bp.name, fund_bp.name, round_bp.name}
-        self.ignore_endpoints = {f"{index_bp.name}.{go_back.__name__}"}
+        self.ignore_endpoints = {
+            f"{index_bp.name}.{go_back.__name__}",
+            f"{index_bp.name}.{preview_form.__name__}",
+        }
         self.reset_endpoints = {
             f"{index_bp.name}.{dashboard.__name__}",
             f"{fund_bp.name}.{view_all_funds.__name__}",


### PR DESCRIPTION
### Ticket

[Back link needs to be clicked twice when forms are previewed in FAB](https://mhclgdigital.atlassian.net/browse/FS-5031)

### Description

Currently when you are on this page and click 'Preview template (opens in a new tab)', then click 'Back', you remain on the same page instead of actually going back. This PR fixes that.

### How to test

1. Navigate to a template details page (e.g., `/templates/[template-id]`)
2. Click "Preview template (opens in a new tab)"
3. Close the preview tab and return to the template details page
4. Click the "Back" link in the top left corner
5. Verify you are redirected to the templates list page in a single click