### PR TITLE
Adding simple names to all GitHub workflow jobs for readability

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -21,17 +21,20 @@ on:
 
 jobs:
   setup:
+    name: Setup
     uses: communitiesuk/funding-service-design-workflows/.github/workflows/determine-jobs.yml@main
     with:
       environment: ${{ inputs.environment }}
 
   unit_tests:
+    name: Run unit tests
     uses: communitiesuk/funding-service-design-workflows/.github/workflows/pre-deploy.yml@main
     with:
       postgres_unit_testing: true
       db_name: fab_store_test
 
   paketo_build:
+    name: Package and build application
     needs: [ setup, unit_tests ]
     permissions:
       packages: write
@@ -43,6 +46,7 @@ jobs:
       assets_required: true
 
   dev_deploy:
+    name: Deploy to Dev
     needs: [ paketo_build ]
     if: ${{ contains(fromJSON(needs.setup.outputs.jobs_to_run), 'dev') }}
     uses: communitiesuk/funding-service-design-workflows/.github/workflows/standard-deploy.yml@main
@@ -58,7 +62,7 @@ jobs:
   dev_e2e_test:
     # Do not run these against the prod environment without addressing the auth/JWT self-signing done by e2e tests.
     if: ${{ contains(fromJSON(needs.setup.outputs.jobs_to_run), 'dev') && (github.event_name == 'push' || inputs.run_e2e_tests == true) }}
-    name: Run E2E Dev
+    name: Run E2E tests vs Dev
     needs: [ dev_deploy, setup ]
     uses: ./.github/workflows/test_e2e_aws.yml
     with:
@@ -68,6 +72,7 @@ jobs:
   test_deploy:
     needs: [ paketo_build, setup ]
     if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'test') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') )}}
+    name: Deploy to Test
     uses: communitiesuk/funding-service-design-workflows/.github/workflows/standard-deploy.yml@main
     secrets:
       AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
@@ -83,7 +88,7 @@ jobs:
   test_e2e_test:
     # Do not run these against the prod environment without addressing the auth/JWT self-signing done by e2e tests.
     if: ${{ contains(fromJSON(needs.setup.outputs.jobs_to_run), 'test') && (github.event_name == 'push' || inputs.run_e2e_tests == true) }}
-    name: Run E2E Test
+    name: Run E2E tests vs Test
     needs: [ test_deploy, setup ]
     uses: ./.github/workflows/test_e2e_aws.yml
     with:
@@ -93,6 +98,7 @@ jobs:
   uat_deploy:
     needs: [ test_e2e_test, paketo_build, setup ]
     if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'uat') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') )}}
+    name: Deploy to UAT
     uses: communitiesuk/funding-service-design-workflows/.github/workflows/standard-deploy.yml@main
     secrets:
       AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}

--- a/.github/workflows/test_e2e_aws.yml
+++ b/.github/workflows/test_e2e_aws.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   run_tests:
-    name: e2e tests
+    name: Run E2E tests
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read  # This is required for actions/checkout


### PR DESCRIPTION
### Description

We are missing job names on our GitHub workflow jobs, meaning that we are forced to use whatever label we've assigned to the job in the code e.g., `dev_deploy`.

This PR adds human-readable names to all jobs.

### Screenshot of UI changes

![image](https://github.com/user-attachments/assets/6fa3710f-6d8c-4841-850a-192d54a043f5)