### PR TITLE
Run e2e test against pr to verify the changes

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -33,9 +33,52 @@ jobs:
       postgres_unit_testing: true
       db_name: fab_store_test
 
+  e2e:
+    if: github.event_name == 'push'
+    name: Run E2E tests
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ubuntu-latest
+    container: mcr.microsoft.com/playwright:v1.47.0-noble@sha256:3d41153494e2b12a5a5fa6e26cf1e854c3997d13758754d46e7bf902b5ba09b1
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: password # pragma: allowlist secret
+          POSTGRES_USER: postgres # pragma: allowlist secret
+          POSTGRES_DB: fab_store # pragma: allowlist secret
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U test_user -d test_db"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Install uv with Caching
+        uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231 # v5
+        with:
+          enable-cache: true
+      - name: Apply Database Migrations
+        run: uv run --frozen flask db upgrade
+        env:
+          DATABASE_URL: postgresql://postgres:password@postgres:5432/fab_store # pragma: allowlist secret
+      - name: Start Flask Application
+        run: uv run --frozen flask run --no-debugger --host 0.0.0.0 --port 8080 &
+        env:
+          DATABASE_URL: postgresql://postgres:password@postgres:5432/fab_store # pragma: allowlist secret
+          RSA256_PUBLIC_KEY_BASE64: "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlHZU1BMEdDU3FHU0liM0RRRUJBUVVBQTRHTUFEQ0JpQUtCZ0hHYnRGMXlWR1crckNBRk9JZGFrVVZ3Q2Z1dgp4SEUzOGxFL2kwS1dwTXdkU0haRkZMWW5IakJWT09oMTVFaWl6WXphNEZUSlRNdkwyRTRRckxwcVlqNktFNnR2CkhyaHlQL041ZnlwU3p0OHZDajlzcFo4KzBrRnVjVzl6eU1rUHVEaXNZdG1rV0dkeEJta2QzZ3RZcDNtT0k1M1YKVkRnS2J0b0lGVTNzSWs1TkFnTUJBQUU9Ci0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQ==" # pragma: allowlist secret
+      - name: Wait for Application to Initialize
+        run: sleep 5
+      - name: Execute End-to-End Tests
+        run: uv run --frozen pytest --e2e --e2e-env e2e
+
   paketo_build:
     name: Package and build application
-    needs: [ setup, unit_tests ]
+    needs: [ setup, unit_tests, e2e ]
     permissions:
       packages: write
     uses: communitiesuk/funding-service-design-workflows/.github/workflows/package.yml@main

--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -18,6 +18,7 @@ on:
         type: boolean
         description: Run e2e tests after deployment
   push:
+    branches: [ main ]
 
 jobs:
   setup:
@@ -33,52 +34,9 @@ jobs:
       postgres_unit_testing: true
       db_name: fab_store_test
 
-  e2e:
-    if: github.event_name == 'push'
-    name: Run E2E tests
-    permissions:
-      id-token: write
-      contents: read
-    runs-on: ubuntu-latest
-    container: mcr.microsoft.com/playwright:v1.47.0-noble@sha256:3d41153494e2b12a5a5fa6e26cf1e854c3997d13758754d46e7bf902b5ba09b1
-    services:
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_PASSWORD: password # pragma: allowlist secret
-          POSTGRES_USER: postgres # pragma: allowlist secret
-          POSTGRES_DB: fab_store # pragma: allowlist secret
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U test_user -d test_db"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - name: Install uv with Caching
-        uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231 # v5
-        with:
-          enable-cache: true
-      - name: Apply Database Migrations
-        run: uv run --frozen flask db upgrade
-        env:
-          DATABASE_URL: postgresql://postgres:password@postgres:5432/fab_store # pragma: allowlist secret
-      - name: Start Flask Application
-        run: uv run --frozen flask run --no-debugger --host 0.0.0.0 --port 8080 &
-        env:
-          DATABASE_URL: postgresql://postgres:password@postgres:5432/fab_store # pragma: allowlist secret
-          RSA256_PUBLIC_KEY_BASE64: "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlHZU1BMEdDU3FHU0liM0RRRUJBUVVBQTRHTUFEQ0JpQUtCZ0hHYnRGMXlWR1crckNBRk9JZGFrVVZ3Q2Z1dgp4SEUzOGxFL2kwS1dwTXdkU0haRkZMWW5IakJWT09oMTVFaWl6WXphNEZUSlRNdkwyRTRRckxwcVlqNktFNnR2CkhyaHlQL041ZnlwU3p0OHZDajlzcFo4KzBrRnVjVzl6eU1rUHVEaXNZdG1rV0dkeEJta2QzZ3RZcDNtT0k1M1YKVkRnS2J0b0lGVTNzSWs1TkFnTUJBQUU9Ci0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQ==" # pragma: allowlist secret
-      - name: Wait for Application to Initialize
-        run: sleep 5
-      - name: Execute End-to-End Tests
-        run: uv run --frozen pytest --e2e --e2e-env e2e
-
   paketo_build:
     name: Package and build application
-    needs: [ setup, unit_tests, e2e ]
+    needs: [ setup, unit_tests ]
     permissions:
       packages: write
     uses: communitiesuk/funding-service-design-workflows/.github/workflows/package.yml@main

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -1,0 +1,54 @@
+name: Validate PR
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches-ignore: [ main ]
+
+jobs:
+  unit_tests:
+    name: Run unit tests
+    uses: communitiesuk/funding-service-design-workflows/.github/workflows/pre-deploy.yml@main
+    with:
+      postgres_unit_testing: true
+      db_name: fab_store_test
+
+  e2e_tests:
+    name: Run E2E tests
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ubuntu-latest
+    container: mcr.microsoft.com/playwright:v1.47.0-noble@sha256:3d41153494e2b12a5a5fa6e26cf1e854c3997d13758754d46e7bf902b5ba09b1
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: password # pragma: allowlist secret
+          POSTGRES_USER: postgres # pragma: allowlist secret
+          POSTGRES_DB: fab_store # pragma: allowlist secret
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U test_user -d test_db"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Install uv with Caching
+        uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231 # v5
+        with:
+          enable-cache: true
+      - name: Apply Database Migrations
+        run: uv run --frozen flask db upgrade
+        env:
+          DATABASE_URL: postgresql://postgres:password@postgres:5432/fab_store # pragma: allowlist secret
+      - name: Start Flask Application
+        run: uv run --frozen flask run --no-debugger --host 0.0.0.0 --port 8080 &
+        env:
+          DATABASE_URL: postgresql://postgres:password@postgres:5432/fab_store # pragma: allowlist secret
+          RSA256_PUBLIC_KEY_BASE64: "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlHZU1BMEdDU3FHU0liM0RRRUJBUVVBQTRHTUFEQ0JpQUtCZ0hHYnRGMXlWR1crckNBRk9JZGFrVVZ3Q2Z1dgp4SEUzOGxFL2kwS1dwTXdkU0haRkZMWW5IakJWT09oMTVFaWl6WXphNEZUSlRNdkwyRTRRckxwcVlqNktFNnR2CkhyaHlQL041ZnlwU3p0OHZDajlzcFo4KzBrRnVjVzl6eU1rUHVEaXNZdG1rV0dkeEJta2QzZ3RZcDNtT0k1M1YKVkRnS2J0b0lGVTNzSWs1TkFnTUJBQUU9Ci0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQ==" # pragma: allowlist secret
+      - name: Execute End-to-End Tests
+        run: uv run --frozen pytest --e2e --e2e-env e2e

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -1,7 +1,5 @@
 name: Validate PR
 on:
-  pull_request:
-    branches: [ main ]
   push:
     branches-ignore: [ main ]
 
@@ -12,6 +10,18 @@ jobs:
     with:
       postgres_unit_testing: true
       db_name: fab_store_test
+
+  paketo_build:
+    name: Package and build application
+    needs: [ unit_tests ]
+    permissions:
+      packages: write
+    uses: communitiesuk/funding-service-design-workflows/.github/workflows/package.yml@main
+    with:
+      version_to_build: sha-${{ github.sha }}
+      owner: ${{ github.repository_owner }}
+      application: funding-service-design-fund-application-builder
+      assets_required: true
 
   e2e_tests:
     name: Run E2E tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ def pytest_addoption(parser):
         action="store",
         default="local",
         help="choose the environment that e2e tests will target",
-        choices=("local", "dev", "test"),
+        choices=("local", "dev", "test", "e2e"),
     )
 
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -21,7 +21,7 @@ def get_e2e_params(request):
     e2e_env = request.config.getoption("e2e_env", "local")
     vault_profile = request.config.getoption("e2e_aws_vault_profile", None)
     session_token_from_env = os.getenv("AWS_SESSION_TOKEN", None)
-    if not session_token_from_env and e2e_env != "local" and not vault_profile:
+    if not session_token_from_env and e2e_env != "local" and e2e_env != "e2e" and not vault_profile:
         sys.exit("Must supply e2e-aws-vault-profile with e2e-env")
     yield {
         "e2e_env": e2e_env,
@@ -41,6 +41,11 @@ def domains(request: pytest.FixtureRequest, get_e2e_params) -> FabDomains:
         case "local":
             return FabDomains(
                 fab_url="https://fund-application-builder.levellingup.gov.localhost:3011",
+                cookie_domain=".levellingup.gov.localhost",
+            )
+        case "e2e":
+            return FabDomains(
+                fab_url="http://fund-application-builder.levellingup.gov.localhost:8080",
                 cookie_domain=".levellingup.gov.localhost",
             )
         case "dev":
@@ -79,7 +84,7 @@ def e2e_test_secrets(request: pytest.FixtureRequest, get_e2e_params) -> EndToEnd
     e2e_env = get_e2e_params["e2e_env"]
     e2e_aws_vault_profile = get_e2e_params["e2e_aws_vault_profile"]
 
-    if e2e_env == "local":
+    if e2e_env == "local" or e2e_env == "e2e":
         return LocalEndToEndSecrets()
 
     if e2e_env in {"dev", "test"}:


### PR DESCRIPTION
**Ticket:  https://mhclgdigital.atlassian.net/browse/FS-5020**

### Change description

When user creates a PR it should run the e2e locally inside GitHub actions and verify the changes are not going to brake any of the user journeys 

**Why we did not used the packito image ?**

when we install that in the AWS environment then that environment has the access level needed to run mkdir, file move etc.. but when we start the container inside the Github it gives a permission denied error

also there is no much difference the way that we star the app since we use the developed code & sole purpose to check the code works according to the user flows

**What changes that have implemented ?**

starting the Postgres sql in the GitHub workflow and apply the db changes finally start app & run against local environment

- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")