### PR TITLE
Add playwright as direct dependency in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,4 +66,5 @@ dev = [
     "ruff==0.11.0",
     "pytest-playwright==0.7.0",
     "Faker==37.0.1",
+    "playwright==1.51.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,5 +66,5 @@ dev = [
     "ruff==0.11.0",
     "pytest-playwright==0.7.0",
     "Faker==37.0.1",
-    "playwright==1.51.1",
+    "playwright==1.51.0",
 ]


### PR DESCRIPTION
Fix issue where Renovate updates Playwright Docker tags in workflow files without updating the corresponding Python package version. This caused E2E test failures when the Docker container (v1.51.1) and Python dependency (v1.47.0) versions became mismatched - see PR: https://github.com/communitiesuk/funding-service-design-fund-application-builder/pull/346

By explicitly including playwright in our dependencies, Renovate can track and update it properly, ensuring version consistency between our Docker environment and Python dependencies.