### PR TITLE
FS-4954 - Simplifying the 'Build application' page when there are no sections in an application

### DIFF
--- a/app/blueprints/application/templates/build_application.html
+++ b/app/blueprints/application/templates/build_application.html
@@ -12,13 +12,15 @@
                 <p class="govuk-body">Build the application by adding sections and using templates.</p>
             {% endif %}
             <p class="govuk-body">Application name: {{ fund.title_json["en"] }}</p>
-            <p class="govuk-body">Status:
-                <span class="govuk-tag {% if round.status == 'Complete' %}govuk-tag--green{% else %}govuk-tag--blue{% endif %}">
-                    {{ round.status }}
-                </span>
-            </p>
+            {% if round.sections|length > 0 %}
+                <p class="govuk-body">Status:
+                    <span class="govuk-tag {% if round.status == 'Complete' %}govuk-tag--green{% else %}govuk-tag--blue{% endif %}">
+                        {{ round.status }}
+                    </span>
+                </p>
+            {% endif %}
         </div>
-        {% if round.status == 'Complete' %}
+        {% if round.sections|length > 0 and round.status == 'Complete' %}
         <div class="govuk-grid-column-one-third govuk-!-text-align-right">
             <a href="{{ url_for('application_bp.mark_application_in_progress', round_id=round.round_id) }}" class="govuk-button govuk-button--secondary" data-module="govuk-button">
                 Edit application
@@ -26,80 +28,82 @@
         </div>
         {% endif %}
     </div>
-    <ul class="app-task-list__items">
-        {% for section in round.sections %}
-        <li class="task-list__new-design govuk-!-margin-bottom-2">
-                <span class="app-task-list__task-name">
-                    <h3 class="govuk-heading-m">{{ section.index }}. {{ section.name_in_apply_json["en"] }}</h3>
-                </span>
-                <span class="app-task-list__task-actions">
-                    {% if round.status == 'In progress' %}
-                        {% if section.index == round.sections | length %}
-                            <span class="govuk-!-font-size-19 govuk-!-margin-right-2 disabled-link">Down</span>
-                        {% else %}
-                            <a class="govuk-!-font-size-19 govuk-!-margin-right-2 govuk-link--no-visited-state"
-                               href='{{ url_for("application_bp.move_section_down_route",round_id=round.round_id, section_id=section.section_id) }}'>Down</a>
+    {% if round.sections|length > 0 %}
+        <ul class="app-task-list__items">
+            {% for section in round.sections %}
+            <li class="task-list__new-design govuk-!-margin-bottom-2">
+                    <span class="app-task-list__task-name">
+                        <h3 class="govuk-heading-m">{{ section.index }}. {{ section.name_in_apply_json["en"] }}</h3>
+                    </span>
+                    <span class="app-task-list__task-actions">
+                        {% if round.status == 'In progress' %}
+                            {% if section.index == round.sections | length %}
+                                <span class="govuk-!-font-size-19 govuk-!-margin-right-2 disabled-link">Down</span>
+                            {% else %}
+                                <a class="govuk-!-font-size-19 govuk-!-margin-right-2 govuk-link--no-visited-state"
+                                   href='{{ url_for("application_bp.move_section_down_route",round_id=round.round_id, section_id=section.section_id) }}'>Down</a>
+                            {% endif %}
+                            {% if section.index == 1 %}
+                                <span class="govuk-!-font-size-19 govuk-!-margin-right-2 disabled-link">Up</span>
+                            {% else %}
+                                <a class="govuk-!-font-size-19 govuk-!-margin-right-2 govuk-link--no-visited-state"
+                                   href='{{ url_for("application_bp.move_section_up_route",round_id=round.round_id, section_id=section.section_id) }}'>Up</a>
+                            {% endif %}
+                            <a class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0"
+                               href='{{ url_for("application_bp.section", round_id=round.round_id, section_id=section.section_id) }}'>Edit</a>
                         {% endif %}
-                        {% if section.index == 1 %}
-                            <span class="govuk-!-font-size-19 govuk-!-margin-right-2 disabled-link">Up</span>
-                        {% else %}
-                            <a class="govuk-!-font-size-19 govuk-!-margin-right-2 govuk-link--no-visited-state"
-                               href='{{ url_for("application_bp.move_section_up_route",round_id=round.round_id, section_id=section.section_id) }}'>Up</a>
-                        {% endif %}
-                        <a class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0"
-                           href='{{ url_for("application_bp.section", round_id=round.round_id, section_id=section.section_id) }}'>Edit</a>
-                    {% endif %}
-                </span>
-        </li>
-        <li>
-            <ul class="app-task-list__items">
-                {% for form in section.forms %}
-                    <li class="app-task-list__item task-list__new-design">
-                        <span class="app-task-list__task-name">
-                            <h3 class="govuk-body">
-                                <a class="govuk-link govuk-link--no-visited-state"
-                                    target="_blank"
-                                    href='{{ url_for("index_bp.preview_form", form_id=form.form_id) }}'>
-                                    {{ form.name_in_apply_json["en"] }} (previews in a new tab)
-                                </a>
-                            </h3>
-                        </span>
-                        <span class="app-task-list__task-actions">
-                            <a class="govuk-link--no-visited-state govuk-!-font-size-19" href="{{ url_for('application_bp.view_form_questions', round_id=round.round_id, section_id=section.section_id, form_id=form.form_id) }}">View questions</a>
-                        </span>
-                    </li>
-                {% endfor %}
-            </ul>
-        </li>
-        {% endfor %}
-    </ul>
+                    </span>
+            </li>
+            <li>
+                <ul class="app-task-list__items">
+                    {% for form in section.forms %}
+                        <li class="app-task-list__item task-list__new-design">
+                            <span class="app-task-list__task-name">
+                                <h3 class="govuk-body">
+                                    <a class="govuk-link govuk-link--no-visited-state"
+                                        target="_blank"
+                                        href='{{ url_for("index_bp.preview_form", form_id=form.form_id) }}'>
+                                        {{ form.name_in_apply_json["en"] }} (previews in a new tab)
+                                    </a>
+                                </h3>
+                            </span>
+                            <span class="app-task-list__task-actions">
+                                <a class="govuk-link--no-visited-state govuk-!-font-size-19" href="{{ url_for('application_bp.view_form_questions', round_id=round.round_id, section_id=section.section_id, form_id=form.form_id) }}">View questions</a>
+                            </span>
+                        </li>
+                    {% endfor %}
+                </ul>
+            </li>
+            {% endfor %}
+        </ul>
+    {% endif %}
     {% if round.status == 'In progress' %}
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
-                {% if round.status == 'In progress' %}
-                    {{
-                        govukButton({
-                            "text": "Add section",
-                            "href": url_for("application_bp.section", round_id=round.round_id),
-                            "classes": "govuk-button--secondary"
-                        })
-                    }}
-                {% endif %}
+                {{
+                    govukButton({
+                        "text": "Add section",
+                        "href": url_for("application_bp.section", round_id=round.round_id),
+                        "classes": "govuk-button--secondary"
+                    })
+                }}
             </div>
-            <div class="govuk-grid-column-one-third govuk-!-text-align-right">
-                <p class="govuk-body">
-                    <a class="govuk-link" href="{{ url_for('application_bp.view_all_questions', round_id=round.round_id) }}">View all application questions</a>
-                </p>
+            {% if round.sections|length > 0 %}
+                <div class="govuk-grid-column-one-third govuk-!-text-align-right">
+                    <p class="govuk-body">
+                        <a class="govuk-link" href="{{ url_for('application_bp.view_all_questions', round_id=round.round_id) }}">View all application questions</a>
+                    </p>
+                </div>
             </div>
-        </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-two-thirds">
-                <p class="govuk-body">
-                    <a class="govuk-link" href="{{ url_for('application_bp.create_export_files', round_id=round.round_id) }}">Download application ZIP file</a>
-                </p>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-two-thirds">
+                    <p class="govuk-body">
+                        <a class="govuk-link" href="{{ url_for('application_bp.create_export_files', round_id=round.round_id) }}">Download application ZIP file</a>
+                    </p>
+                </div>
             </div>
-        </div>
-    {% else %}
+            {% endif %}
+    {% elif round.sections|length > 0 %}
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
                 <p class="govuk-body">
@@ -113,16 +117,15 @@
             </div>
         </div>
     {% endif %}
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-three-quarters">
-            {% if round.status == 'In progress' %}
-            <p class="govuk-body">
-                <a href="{{ url_for('application_bp.mark_application_complete', round_id=round.round_id) }}" class="govuk-button govuk-button--success" data-module="govuk-button">
-                    Mark application complete
-                </a>
-            </p>
-            {% endif %}
+    {% if round.sections|length > 0 and round.status == 'In progress' %}
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-three-quarters">
+                <p class="govuk-body">
+                    <a href="{{ url_for('application_bp.mark_application_complete', round_id=round.round_id) }}" class="govuk-button govuk-button--success" data-module="govuk-button">
+                        Mark application complete
+                    </a>
+                </p>
+            </div>
         </div>
-    </div>
-
+    {% endif %}
 {% endblock content %}


### PR DESCRIPTION
### Ticket

[Mark application as complete](https://mhclgdigital.atlassian.net/browse/FS-4954)

### Description

The 'Build application' page is much simplified when there are no sections in an application. The following elements are hidden:

- "Status: X" text
- "Download application ZIP file" button
- "View all application questions" button
- "Mark application complete" button

This should have been implemented as part of the original work on 'Mark application as complete' but was overlooked.

### Screenshots of UI changes

![image](https://github.com/user-attachments/assets/c5288f8a-8b11-4c6b-ada5-da62756a42a3)
