### PR TITLE
FS-5053 - Iterate content on 'Mark as complete' confirmation page

### DIFF
--- a/app/blueprints/application/templates/application_complete.html
+++ b/app/blueprints/application/templates/application_complete.html
@@ -9,24 +9,17 @@
       </h1>
     </div>
 
-    <p class="govuk-body">The status of this application has been changed to 'complete'.</p>
+    <p class="govuk-body">You can still edit your application at any time.</p>
 
-    <h3 class="govuk-heading-m">What happens next</h3>
+    <h3 class="govuk-heading-m">What you need to do next</h3>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li><a href="{{ url_for('application_bp.create_export_files', round_id=round.round_id) }}" class="govuk-link">Download the application ZIP file</a> and send it to the Live Services team</li>
-      <li>The application can be edited at any time. Editing a complete application will automatically change its status to 'In progress'.</li>
-    </ul>
-
-    <p class="govuk-body">
+    <p class="govuk-body"><a href="{{ url_for('application_bp.create_export_files', round_id=round.round_id) }}" class="govuk-link">Download the application ZIP file</a> and send it to the Live Services team.</p>
+    <p class="govuk-body govuk-!-margin-top-9">
       <a href="{{ url_for('application_bp.build_application', round_id=round.round_id) }}" class="govuk-link">Back to application</a>
     </p>
-
-    <div class="govuk-button-group">
-      <a href="{{ url_for('index_bp.dashboard') }}" class="govuk-button govuk-button--secondary">
-        Back to home
-      </a>
-    </div>
+    <p class="govuk-body">
+      <a href="{{ url_for('index_bp.dashboard') }}" class="govuk-link">Go to home page</a>
+    </p>
   </div>
 </div>
 {% endblock %}

--- a/tests/unit/blueprints/application/test_routes.py
+++ b/tests/unit/blueprints/application/test_routes.py
@@ -235,29 +235,21 @@ def test_application_complete_page(flask_test_client, seed_dynamic_data):
     status_text = soup.find(
         "p",
         class_="govuk-body",
-        string=lambda text: "status of this application has been changed" in text if text else False,
+        string=lambda text: "You can still edit your application at any time" in text if text else False,
     )
     assert status_text is not None
 
     # Check for the "What happens next" heading
-    next_heading = soup.find("h3", class_="govuk-heading-m", string="What happens next")
+    next_heading = soup.find("h3", class_="govuk-heading-m", string="What you need to do next")
     assert next_heading is not None
-
-    # Check for the bullet points
-    bullet_list = soup.find("ul", class_="govuk-list--bullet")
-    assert bullet_list is not None
-    bullet_points = bullet_list.find_all("li")
-    assert len(bullet_points) == 2
 
     # Check for the back to application link
     back_link = soup.find("a", string="Back to application")
     assert back_link is not None
 
-    # Check for the back to home button
-    home_button = soup.find(
-        "a", class_="govuk-button--secondary", string=lambda text: "Back to home" in text if text else False
-    )
-    assert home_button is not None
+    # Check for the go to home link
+    home_link = soup.find("a", string="Go to home page")
+    assert home_link is not None
 
 
 @pytest.mark.usefixtures("set_auth_cookie", "patch_validate_token_rs256_internal_user")


### PR DESCRIPTION
### Ticket

[Iterate 'mark as completed' confirmation page content](https://mhclgdigital.atlassian.net/browse/FS-5053)

### Description

Content changes as per ticket.

### Screenshot of UI changes

![image](https://github.com/user-attachments/assets/9159837c-8ff9-4c37-9b85-f80e92f1cbd7)