### PR TITLE
FS-4810 - Putting FAB into production

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -18,7 +18,7 @@ on:
         type: boolean
         description: Run e2e tests after deployment
   push:
-    branches: [ main, deploy-to-prod ]
+    branches: [ main ]
 
 jobs:
   setup:
@@ -125,7 +125,7 @@ jobs:
 
   prod_deploy:
     needs: [ test_e2e_test, paketo_build, setup ]
-    if: ${{ always() && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') )}}
+    if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'prod') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') )}}
     name: Deploy to prod
     concurrency:
       group: deploy-prod
@@ -139,7 +139,7 @@ jobs:
     with:
       environment: prod
       app_name: fund-application-builder
-      run_db_migrations: false
+      run_db_migrations: true
       image_location: ${{ needs.paketo_build.outputs.image_location }}
       notify_slack: true
       notify_slack_on_deployment: true

--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -125,7 +125,7 @@ jobs:
 
   prod_deploy:
     needs: [ test_e2e_test, paketo_build, setup ]
-    if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'prod') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') )}}
+    if: ${{ always() && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') )}}
     name: Deploy to prod
     concurrency:
       group: deploy-prod

--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -18,7 +18,7 @@ on:
         type: boolean
         description: Run e2e tests after deployment
   push:
-    branches: [ main ]
+    branches: [ main, deploy-to-prod ]
 
 jobs:
   setup:

--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -18,7 +18,7 @@ on:
         type: boolean
         description: Run e2e tests after deployment
   push:
-    branches: [ main ]
+    branches: [ main, deploy-to-prod ]
 
 jobs:
   setup:
@@ -117,6 +117,27 @@ jobs:
       SLACK_DEPLOYMENTS_CHANNEL_ID: ${{ secrets.SLACK_DEPLOYMENTS_CHANNEL_ID }}
     with:
       environment: uat
+      app_name: fund-application-builder
+      run_db_migrations: true
+      image_location: ${{ needs.paketo_build.outputs.image_location }}
+      notify_slack: true
+      notify_slack_on_deployment: false
+
+  prod_deploy:
+    needs: [ test_e2e_test, paketo_build, setup ]
+    if: ${{ always() && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') )}}
+    name: Deploy to prod
+    concurrency:
+      group: deploy-prod
+      cancel-in-progress: false
+    uses: communitiesuk/funding-service-design-workflows/.github/workflows/standard-deploy.yml@main
+    secrets:
+      AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_NOTIFICATION_CHANNEL_ID: ${{ secrets.SLACK_NOTIFICATION_CHANNEL_ID }}
+      SLACK_DEPLOYMENTS_CHANNEL_ID: ${{ secrets.SLACK_DEPLOYMENTS_CHANNEL_ID }}
+    with:
+      environment: prod
       app_name: fund-application-builder
       run_db_migrations: true
       image_location: ${{ needs.paketo_build.outputs.image_location }}

--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -18,7 +18,7 @@ on:
         type: boolean
         description: Run e2e tests after deployment
   push:
-    branches: [ main, deploy-to-prod ]
+    branches: [ main ]
 
 jobs:
   setup:
@@ -125,7 +125,7 @@ jobs:
 
   prod_deploy:
     needs: [ test_e2e_test, paketo_build, setup ]
-    if: ${{ always() && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') )}}
+    if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'prod') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') )}}
     name: Deploy to prod
     concurrency:
       group: deploy-prod

--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -139,7 +139,7 @@ jobs:
     with:
       environment: prod
       app_name: fund-application-builder
-      run_db_migrations: true
+      run_db_migrations: false
       image_location: ${{ needs.paketo_build.outputs.image_location }}
       notify_slack: true
       notify_slack_on_deployment: true

--- a/app/blueprints/index/routes.py
+++ b/app/blueprints/index/routes.py
@@ -50,13 +50,13 @@ def preview_form(form_id):
 
     try:
         publish_response = requests.post(
-            url=f"{Config.FORM_RUNNER_URL}/publish", json={"id": form_id, "configuration": form_json}
-        )
+            url=f"{Config.FORM_RUNNER_EXTERNAL_HOST}/publish", json={"id": form_id, "configuration": form_json}
+        )  # Need to publish via external host not internal because prod FAB publishes to UAT Runner (different AWS env)
         if not str(publish_response.status_code).startswith("2"):
             return "Error during form publish", 500
     except Exception as e:
         return f"unable to publish form: {str(e)}", 500
-    return redirect(f"{Config.FORM_RUNNER_URL_REDIRECT}/{form_id}")
+    return redirect(f"{Config.FORM_RUNNER_EXTERNAL_HOST}/{form_id}")
 
 
 @index_bp.route("/download/<form_id>", methods=["GET"])

--- a/app/blueprints/index/routes.py
+++ b/app/blueprints/index/routes.py
@@ -50,8 +50,8 @@ def preview_form(form_id):
 
     try:
         publish_response = requests.post(
-            url=f"{Config.FORM_RUNNER_EXTERNAL_HOST}/publish", json={"id": form_id, "configuration": form_json}
-        )  # Need to publish via external host not internal because prod FAB publishes to UAT Runner (different AWS env)
+            url=f"{Config.FORM_RUNNER_INTERNAL_HOST}/publish", json={"id": form_id, "configuration": form_json}
+        )
         if not str(publish_response.status_code).startswith("2"):
             return "Error during form publish", 500
     except Exception as e:

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -18,8 +18,10 @@ class DefaultConfig(object):
         "FUND_APPLICATION_BUILDER_HOST", "https://fund-application-builder.levellingup.gov.localhost:3011"
     )
     FAB_SAVE_PER_PAGE = getenv("FAB_SAVE_PER_PAGE", "dev/save")
-    FORM_RUNNER_URL = getenv("FORM_RUNNER_INTERNAL_HOST", "http://form-runner:3009")
-    FORM_RUNNER_URL_REDIRECT = getenv("FORM_RUNNER_EXTERNAL_HOST", "https://form-runner.levellingup.gov.localhost:3009")
+    FORM_RUNNER_INTERNAL_HOST = getenv("FORM_RUNNER_INTERNAL_HOST", "http://form-runner:3009")
+    FORM_RUNNER_EXTERNAL_HOST = getenv(
+        "FORM_RUNNER_EXTERNAL_HOST", "https://form-runner.levellingup.gov.localhost:3009"
+    )
     FORM_DESIGNER_URL_REDIRECT = getenv(
         "FORM_DESIGNER_EXTERNAL_HOST", "https://form-designer.levellingup.gov.localhost:3000"
     )

--- a/copilot/fsd-fund-application-builder/addons/fsd-fund-application-builder-cluster.yml
+++ b/copilot/fsd-fund-application-builder/addons/fsd-fund-application-builder-cluster.yml
@@ -104,7 +104,7 @@ Resources:
         !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdfundapplicationbuilderclusterAuroraSecret, ":SecretString:password}}" ]]  # pragma: allowlist secret
       DatabaseName: !Ref fsdfundapplicationbuilderclusterDBName
       Engine: 'aurora-postgresql'
-      EngineVersion: '14.4'
+      EngineVersion: '14.9'
       DBClusterParameterGroupName: !Ref fsdfundapplicationbuilderclusterDBClusterParameterGroup
       DBSubnetGroupName: !Ref fsdfundapplicationbuilderclusterDBSubnetGroup
       Port: 5432

--- a/copilot/fsd-fund-application-builder/manifest.yml
+++ b/copilot/fsd-fund-application-builder/manifest.yml
@@ -114,24 +114,23 @@ environments:
         value: 80
       requests: 30
       response_time: 2s
-#   prod:
-#     http:
-#       alias: ["fund-application-builder.prod.access-funding.levellingup.gov.uk", "fund-application-builder.access-funding.levellingup.gov.uk"]
-#       hosted_zone: Z0686469NF3ZJTU9I02M
-#     variables:
-#       COOKIE_DOMAIN: ".levellingup.gov.uk"
-#       AUTHENTICATOR_HOST: "https://authenticator.access-funding.levellingup.gov.uk"
-#       APPLICANT_fund-application-builder_HOST: "https://fund-application-builder.access-funding.levellingup.gov.uk"
-#       ASSESSMENT_fund-application-builder_HOST: "https://assessment.access-funding.levellingup.gov.uk"
-#       FORMS_SERVICE_PUBLIC_HOST: "https://forms.access-funding.levellingup.gov.uk"
-#       FLASK_ENV: production
-#     count:
-#       range: 2-4
-#       cooldown:
-#         in: 60s
-#         out: 30s
-#       cpu_percentage:
-#         value: 70
-#       memory_percentage:
-#         value: 80
-#       requests: 30
+  prod:
+    http:
+      alias: "fund-application-builder.access-funding.communities.gov.uk"
+    variables:
+      FUND_APPLICATION_BUILDER_HOST: "https://fund-application-builder.access-funding.communities.gov.uk"
+      AUTHENTICATOR_HOST: "https://account.access-funding.communities.gov.uk"
+      FLASK_ENV: production
+      SENTRY_TRACES_SAMPLE_RATE: 1
+      FORM_RUNNER_EXTERNAL_HOST: "https://application-questions.access-funding.communities.gov.uk"
+      FORM_DESIGNER_EXTERNAL_HOST: "https://form-designer.access-funding.communities.gov.uk"
+    count:
+      range: 2-4
+      cooldown:
+        in: 60s
+        out: 30s
+      cpu_percentage:
+        value: 70
+      memory_percentage:
+        value: 80
+      requests: 30

--- a/copilot/fsd-fund-application-builder/manifest.yml
+++ b/copilot/fsd-fund-application-builder/manifest.yml
@@ -122,8 +122,9 @@ environments:
       AUTHENTICATOR_HOST: "https://account.access-funding.communities.gov.uk"
       FLASK_ENV: production
       SENTRY_TRACES_SAMPLE_RATE: 1
-      FORM_RUNNER_EXTERNAL_HOST: "https://application-questions.access-funding.communities.gov.uk"
-      FORM_DESIGNER_EXTERNAL_HOST: "https://form-designer.access-funding.communities.gov.uk"
+      # Prod points to UAT runner because prod runner does not support /publish endpoint needed for previewing forms
+      FORM_RUNNER_EXTERNAL_HOST: "https://application-questions.access-funding.uat.communities.gov.uk"
+      FORM_DESIGNER_EXTERNAL_HOST: "https://form-designer.access-funding.test.communities.gov.uk"
     count:
       range: 2-4
       cooldown:

--- a/copilot/fsd-fund-application-builder/manifest.yml
+++ b/copilot/fsd-fund-application-builder/manifest.yml
@@ -125,6 +125,9 @@ environments:
       # Prod points to UAT runner because prod runner does not support /publish endpoint needed for previewing forms
       FORM_RUNNER_EXTERNAL_HOST: "https://application-questions.access-funding.uat.communities.gov.uk"
       FORM_DESIGNER_EXTERNAL_HOST: "https://form-designer.access-funding.test.communities.gov.uk"
+      # Internal host needs to be overridden with external host because the internal host points to the service running
+      # in the same AWS env and we are publishing from prod FAB to UAT Runner
+      FORM_RUNNER_INTERNAL_HOST: "https://application-questions.access-funding.uat.communities.gov.uk"
     count:
       range: 2-4
       cooldown:


### PR DESCRIPTION
### Ticket

[Putting FAB in production environment](https://mhclgdigital.atlassian.net/browse/FS-4810)

### Description

We are deploying FAB into production. FAB has been used by users since January, but the top level env has always been UAT. Once we get out to production, we need to restore a dump of the UAT database into production and notify users of the switchover. 

### Notes

Before converting this PR out of draft, we need to..

- [x] - Remove `deploy-to-prod` from the allowed branches for the deployment workflow
- [x] - Re-add the "determine jobs" condition to the prod deploy step `if`
- [x] - Set `run_db_migrations` to `true` for the prod deploy step
- [x] - Ensure that prod FAB points to UAT Form Runner for preview links (Form Runner in prod has "PREVIEW_MODE" disabled to prevent unauthorised publishing of JSON forms to the Redis cache - we need to come up with a better long-term solution)
- [x] - Change Aurora engine from 14.4 to 14.9 in CloudFormation add-on

Before deploying to UAT, we should ensure we take a dump of the UAT database. This is because we will be deploying out a CloudFormation stack change to this env for the first time. We have already tested this stack change on Dev and there were no issues, but good to take precautions and we need to dump UAT regardless.