### PR TITLE
FS-4855: Add delete confirmation for application form section and template

### DIFF
--- a/app/blueprints/application/routes.py
+++ b/app/blueprints/application/routes.py
@@ -41,7 +41,7 @@ from app.export_config.generate_fund_round_form_jsons import (
     generate_form_jsons_for_round,
 )
 from app.export_config.generate_fund_round_html import generate_all_round_html
-from app.shared.forms import SelectFundForm
+from app.shared.forms import DeleteConfirmationForm, SelectFundForm
 from app.shared.helpers import flash_message
 from config import Config
 
@@ -235,10 +235,21 @@ def section(round_id, section_id=None):
     return render_template("section.html", form=form, **params)
 
 
-@application_bp.route("/<round_id>/sections/<section_id>/delete", methods=["GET"])
+@application_bp.route("/<round_id>/sections/<section_id>/delete", methods=["GET", "POST"])  # Sensitive
 def delete_section(round_id, section_id):
-    delete_section_from_round(round_id=round_id, section_id=section_id, cascade=True)
-    return redirect(url_for("application_bp.build_application", round_id=round_id))
+    form = DeleteConfirmationForm()
+
+    if form.validate_on_submit():  # If user confirms deletion
+        delete_section_from_round(round_id=round_id, section_id=section_id, cascade=True)
+        return redirect(url_for("application_bp.build_application", round_id=round_id))
+
+    # Render confirmation page
+    return render_template(
+        "delete_confirmation.html",
+        form=form,
+        cancel_url=url_for("application_bp.section", round_id=round_id, section_id=section_id),
+        delete_action_item="section",
+    )
 
 
 @application_bp.route("/<round_id>/sections/<section_id>/move-up", methods=["GET"])

--- a/app/blueprints/template/routes.py
+++ b/app/blueprints/template/routes.py
@@ -16,6 +16,7 @@ from app.db.queries.application import (
 from app.export_config.generate_all_questions import generate_html
 from app.export_config.generate_form import build_form_json
 from app.export_config.helpers import human_to_kebab_case
+from app.shared.forms import DeleteConfirmationForm
 from app.shared.helpers import flash_message
 
 template_bp = Blueprint(
@@ -167,7 +168,18 @@ def _save_and_return(updated_form, form):
     return redirect(url_for("index_bp.dashboard"))
 
 
-@template_bp.route("/<form_id>/delete", methods=["GET"])
+@template_bp.route("/<form_id>/delete", methods=["GET", "POST"])  # Sensitive
 def delete_template(form_id):
-    delete_form(form_id=form_id, cascade=True)
-    return redirect(url_for("template_bp.view_templates"))
+    form = DeleteConfirmationForm()
+
+    if form.validate_on_submit():  # If user confirms deletion
+        delete_form(form_id=form_id, cascade=True)
+        return redirect(url_for("template_bp.view_templates"))
+
+    # Render confirmation page
+    return render_template(
+        "delete_confirmation.html",
+        form=form,
+        cancel_url=url_for("template_bp.template_details", form_id=form_id),
+        delete_action_item="template",
+    )

--- a/app/shared/forms.py
+++ b/app/shared/forms.py
@@ -1,6 +1,7 @@
 from flask_wtf import FlaskForm
-from govuk_frontend_wtf.wtforms_widgets import GovSelect
+from govuk_frontend_wtf.wtforms_widgets import GovSelect, GovSubmitInput
 from wtforms import SelectField
+from wtforms.fields.simple import SubmitField
 from wtforms.validators import DataRequired
 
 
@@ -10,3 +11,7 @@ class SelectFundForm(FlaskForm):
         widget=GovSelect(),
         validators=[DataRequired(message="Select or add a grant")],
     )
+
+
+class DeleteConfirmationForm(FlaskForm):
+    delete = SubmitField("Yes, delete", widget=GovSubmitInput())

--- a/app/static/src/styles/fab.css
+++ b/app/static/src/styles/fab.css
@@ -101,3 +101,17 @@
     margin-bottom: 2px;
     margin-left: 15px;
 }
+
+.govuk-panel--confirmation-blue {
+    color: #fff; /* Keep text white */
+    background: #1d70b8; /* Use GOV.UK blue */
+    font-size: 24px;
+}
+
+.govuk-panel-\!-left {
+    text-align: left !important; /* Override center alignment */
+}
+
+.govuk-link-\!-white {
+    color: #fff !important;
+}

--- a/app/templates/delete_confirmation.html
+++ b/app/templates/delete_confirmation.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+{% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
+{% set back_link = True %}
+{% block content %}
+  <div class="govuk-panel govuk-panel--confirmation-blue govuk-panel-!-left">
+        <div class="govuk-grid-row">
+             <div class="govuk-grid-column-full">
+                  <h1 class="govuk-panel__title">Are you sure you want to delete this {{ delete_action_item }}?</h1>
+             </div>
+             </div>
+        <div class="govuk-grid-row">
+         <div class="govuk-grid-column-full">
+              <div class="govuk-panel__body">
+                {% set delete_message = "You are about to delete this " ~ delete_action_item %}
+                {% if delete_action_item == "template" %}
+                    {% set delete_message = delete_message ~ ". This action cannot be undone. <br><br>Applications that use this " ~ delete_action_item ~ " will not be affected." %}
+                {% else %}
+                    {% set delete_message = delete_message ~ " and all of its content. <br><br>This action cannot be undone." %}
+                {% endif %}
+                <p>{{ delete_message | safe }}</p>
+              </div>
+         </div>
+         </div>
+        <div class="govuk-grid-row">
+             <div class="govuk-grid-column-full">
+            <form method="post" novalidate>
+                {{ form.csrf_token }}
+                <div class="govuk-button-group govuk-!-margin-bottom-0">
+                    {{ govukButton({
+                      "text": "Yes, delete " ~ delete_action_item,
+                      "classes": "govuk-button--inverse govuk-!-margin-bottom-0",
+                      "type": "submit"
+                    }) }}
+                    <a href="{{ cancel_url }}" class="govuk-link govuk-link-!-white govuk-!-margin-bottom-0">Cancel</a>
+                </div>
+            </form>
+             </div>
+          </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
Ticket: https://mhclgdigital.atlassian.net/browse/FS-4855

### Change description
1. Delete confirmation is added when a template is deleted  or Application section is deleted.

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

1. Delete section:

a. On the ‘Build application’ page, users press ‘Edit’
b. On the ‘Update section’ page, users press ‘Delete section’
c. Users see an Confirmation page (Delete section) and confirm
d. Users return to the updated ‘Build application’ page (section deleted)

2. Delete template:

a.On the ‘Template details’ page, users press ‘Delete template’
b. Users see an Confirmation page (Delete template) and confirm
c.Users return to the updated ‘Templates table’ page (template deleted)

### Screenshots of UI changes (if applicable)
<img width="1099" alt="image" src="https://github.com/user-attachments/assets/e9974f16-b47e-4766-b615-734f7fa025f1" />
<img width="1278" alt="image" src="https://github.com/user-attachments/assets/923f36e8-2a0d-4c8a-9a65-98bdd51044eb" />


