### PR TITLE
Allow manual deployments to prod via GitHub workflow dispatch

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -12,6 +12,7 @@ on:
           - dev
           - test
           - uat
+          - prod
       run_e2e_tests:
         required: false
         default: true


### PR DESCRIPTION
Currently we can manually deploy branches to each of the Dev, Test and UAT AWS environments via the Actions tab in the GitHub UI, by clicking Deploy to AWS -> Run workflow. The prod environment was recently introduced to FAB, and we should add that as a manually deployable environment. This is in-keeping with the approach taken in the Pre-Award repo.