### PR TITLE
Removing the E2E test dependency for UAT and prod deploy jobs

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -104,7 +104,7 @@ jobs:
     secrets: inherit # pragma: allowlist secret
 
   uat_deploy:
-    needs: [ test_e2e_test, paketo_build, setup ]
+    needs: [ test_deploy, paketo_build, setup ]
     if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'uat') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') )}}
     name: Deploy to UAT
     concurrency:
@@ -125,7 +125,7 @@ jobs:
       notify_slack_on_deployment: false
 
   prod_deploy:
-    needs: [ test_e2e_test, paketo_build, setup ]
+    needs: [ uat_deploy, paketo_build, setup ]
     if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'prod') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') )}}
     name: Deploy to prod
     concurrency:


### PR DESCRIPTION
E2E tests in FAB have proven flaky, despite attempted wrangling. They fail intermittently. They shouldn't therefore be a deployment dependency. Instead we can have each deployment job depend on the deployment to the environment just below, creating a chain of deployments or promotions up through the environments.