### PR TITLE
Allow manual deploy via GitHub workflow dispatch only to Dev env

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -10,8 +10,6 @@ on:
         required: true
         options:
           - dev
-          - test
-          - uat
       run_e2e_tests:
         required: false
         default: true


### PR DESCRIPTION
@gidsg recently added protection rules to Pre-Award to prevent manual deployment to every environment except Dev, following the issue where an out-of-date manifest file was deployed and brought the Test environment down.

We should implement the same branch protection rules in FAB. Alongside this, we should ensure that the workflow dispatch (accessible via GitHub Actions tab) does not suggest that manual deployment to any env other than Dev is possible. The supposedly available options are enumerated in the workflow file.