### PR TITLE
Allow manual deployments to prod via GitHub workflow dispatch

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -10,6 +10,9 @@ on:
         required: true
         options:
           - dev
+          - test
+          - uat
+          - prod
       run_e2e_tests:
         required: false
         default: true


### PR DESCRIPTION
Currently we can manually deploy branches to each of the Dev, Test and UAT AWS environments via the Actions tab in the GitHub UI, by clicking Deploy to AWS -> Run workflow. The prod environment was recently introduced to FAB, and we should add that as a manually deployable environment. This is in-keeping with the approach taken in the Pre-Award repo.

_Note: the [original PR](https://github.com/communitiesuk/funding-service-design-fund-application-builder/pull/379) for this change was closed as we thought we'd discovered that the rule introduced by Gideon prevented manual deployment, when in fact it just limits deployment to main branch._