### PR TITLE
FLS-1131 - Add basic auth to FAB in UAT environment

### DIFF
--- a/copilot/fsd-fund-application-builder/manifest.yml
+++ b/copilot/fsd-fund-application-builder/manifest.yml
@@ -114,6 +114,22 @@ environments:
         value: 80
       requests: 30
       response_time: 2s
+    sidecars:
+      nginx:
+        port: 8087
+        image:
+          location: xscys/nginx-sidecar-basic-auth
+        variables:
+          FORWARD_PORT: 8080
+          CLIENT_MAX_BODY_SIZE: 10m
+        secrets:
+          BASIC_AUTH_USERNAME: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_USERNAME
+          BASIC_AUTH_PASSWORD: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_PASSWORD
+    http:
+      target_container: nginx
+      healthcheck:
+        path: /healthcheck
+        port: 8080
   prod:
     http:
       alias: "fund-application-builder.access-funding.communities.gov.uk"


### PR DESCRIPTION
### Ticket

[Add basic auth to FAB UAT environment](https://mhclgdigital.atlassian.net/browse/FLS-1131)

### Description of changes

The UAT environment configuration was updated to include an Nginx sidecar container, routing incoming traffic through it (`target_container: nginx`) to enforce "basic auth" before proxying requests to the main application on port 8080.