### PR TITLE
Use communities.gov.uk domain when running E2E tests locally

### DIFF
--- a/.idea/runConfigurations/FAB.xml
+++ b/.idea/runConfigurations/FAB.xml
@@ -6,7 +6,7 @@
         <option name="PARENT_ENVS" value="true"/>
         <envs>
             <env name="PYTHONUNBUFFERED" value="1"/>
-            <env name="AUTHENTICATOR_HOST" value="https://authenticator.levellingup.gov.localhost:4004"/>
+            <env name="AUTHENTICATOR_HOST" value="https://authenticator.communities.gov.localhost:4004"/>
             <env name="DATABASE_URL"
                  value="postgresql://postgres:password@localhost:5432/fab_store"/> <!--pragma: allowlist secret-->
             <env name="FLASK_DEBUG" value="0"/>

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -15,15 +15,15 @@ class DefaultConfig(object):
     SECRET_KEY = CommonConfig.SECRET_KEY
 
     FUND_APPLICATION_BUILDER_HOST = getenv(
-        "FUND_APPLICATION_BUILDER_HOST", "https://fund-application-builder.levellingup.gov.localhost:3011"
+        "FUND_APPLICATION_BUILDER_HOST", "https://fund-application-builder.communities.gov.localhost:3011"
     )
     FAB_SAVE_PER_PAGE = getenv("FAB_SAVE_PER_PAGE", "dev/save")
     FORM_RUNNER_INTERNAL_HOST = getenv("FORM_RUNNER_INTERNAL_HOST", "http://form-runner:3009")
     FORM_RUNNER_EXTERNAL_HOST = getenv(
-        "FORM_RUNNER_EXTERNAL_HOST", "https://form-runner.levellingup.gov.localhost:3009"
+        "FORM_RUNNER_EXTERNAL_HOST", "https://form-runner.communities.gov.localhost:3009"
     )
     FORM_DESIGNER_URL_REDIRECT = getenv(
-        "FORM_DESIGNER_EXTERNAL_HOST", "https://form-designer.levellingup.gov.localhost:3000"
+        "FORM_DESIGNER_EXTERNAL_HOST", "https://form-designer.communities.gov.localhost:3000"
     )
     SQLALCHEMY_DATABASE_URI = environ.get("DATABASE_URL")
 
@@ -31,7 +31,7 @@ class DefaultConfig(object):
     GENERATE_LOCAL_CONFIG = False
 
     FSD_USER_TOKEN_COOKIE_NAME = "fsd_user_token"
-    AUTHENTICATOR_HOST = getenv("AUTHENTICATOR_HOST", "https://authenticator.levellingup.gov.localhost:4004")
+    AUTHENTICATOR_HOST = getenv("AUTHENTICATOR_HOST", "https://authenticator.communities.gov.localhost:4004")
     LOGOUT_URL_OVERRIDE = f"{AUTHENTICATOR_HOST}/sessions/sign-out?return_app=fund-application-builder&return_path=/"  # noqa: E501
     # RSA 256 Keys
     RSA256_PUBLIC_KEY_BASE64 = getenv("RSA256_PUBLIC_KEY_BASE64")

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -40,14 +40,14 @@ def domains(request: pytest.FixtureRequest, get_e2e_params) -> FabDomains:
     match e2e_env:
         case "local":
             return FabDomains(
-                fab_url="https://fund-application-builder.levellingup.gov.localhost:3011",
-                cookie_domain=".levellingup.gov.localhost",
+                fab_url="https://fund-application-builder.communities.gov.localhost:3011",
+                cookie_domain=".communities.gov.localhost",
                 environment="local",
             )
         case "e2e":
             return FabDomains(
-                fab_url="http://fund-application-builder.levellingup.gov.localhost:8080",
-                cookie_domain=".levellingup.gov.localhost",
+                fab_url="http://fund-application-builder.communities.gov.localhost:8080",
+                cookie_domain=".communities.gov.localhost",
                 environment="e2e",
             )
         case "dev":


### PR DESCRIPTION
This PR on Docker Runner - [Migrate from levellingup to communities domain](https://github.com/communitiesuk/funding-service-design-docker-runner/pull/137) - means that we now run apps locally at communities.gov.uk, not levellingup.gov.uk. However, E2E tests in FAB refer to levellingup.gov.uk, which means when you try to run E2E tests locally for FAB, they simply don't work. This fixes that.