### PR TITLE
FLS-1235: Add e2e check back for UAT and PROD deploy

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -104,7 +104,7 @@ jobs:
     secrets: inherit # pragma: allowlist secret
 
   uat_deploy:
-    needs: [ test_deploy, paketo_build, setup ]
+    needs: [ test_e2e_test, paketo_build, setup ]
     if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'uat') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') )}}
     name: Deploy to UAT
     concurrency:
@@ -125,7 +125,7 @@ jobs:
       notify_slack_on_deployment: false
 
   prod_deploy:
-    needs: [ uat_deploy, paketo_build, setup ]
+    needs: [ test_e2e_test, paketo_build, setup ]
     if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'prod') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') )}}
     name: Deploy to prod
     concurrency:


### PR DESCRIPTION
Ticket: https://mhclgdigital.atlassian.net/browse/FLS-1235


### Change description
- E2E check was disabled for UAT and PROD deploys because they were flaky, but now that they are fixed we should add the checks back in

- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")