### PR TITLE
Move ALLOWED_DOMAINS from variables to secrets

### DIFF
--- a/copilot/fsd-fund-application-builder/manifest.yml
+++ b/copilot/fsd-fund-application-builder/manifest.yml
@@ -54,10 +54,10 @@ variables:
   SENTRY_TRACES_SAMPLE_RATE: 0.02
   FORM_RUNNER_EXTERNAL_HOST: "https://application-questions.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
   FORM_DESIGNER_EXTERNAL_HOST: "https://form-designer.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
-  ALLOWED_DOMAINS: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/FAB_ALLOWED_DOMAINS
 secrets:
   RSA256_PUBLIC_KEY_BASE64: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/RSA256_PUBLIC_KEY_BASE64
   SECRET_KEY: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/SECRET_KEY
+  ALLOWED_DOMAINS: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/FAB_ALLOWED_DOMAINS
 
 # You can override any of the values defined above by environment.
 environments:


### PR DESCRIPTION
Need to store ALLOWED_DOMAINS as a secret not a variable in the AWS Copilot manifest (manifest.yml) otherwise the reference to the secrets location is passed as a useless string to the app.