### PR TITLE
FSPT-342 - Use Test Runner (instead of UAT) for form preview

### DIFF
--- a/app/blueprints/index/routes.py
+++ b/app/blueprints/index/routes.py
@@ -51,7 +51,7 @@ def preview_form(form_id):
 
     try:
         publish_response = requests.post(
-            url=f"{Config.FORM_RUNNER_INTERNAL_HOST}/publish", json={"id": form_id, "configuration": form_json}
+            url=Config.FORM_RUNNER_PUBLISH_URL, json={"id": form_id, "configuration": form_json}
         )
         if not str(publish_response.status_code).startswith("2"):
             return "Error during form publish", 500

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -18,7 +18,7 @@ class DefaultConfig(object):
         "FUND_APPLICATION_BUILDER_HOST", "https://fund-application-builder.communities.gov.localhost:3011"
     )
     FAB_SAVE_PER_PAGE = getenv("FAB_SAVE_PER_PAGE", "dev/save")
-    FORM_RUNNER_INTERNAL_HOST = getenv("FORM_RUNNER_INTERNAL_HOST", "http://form-runner:3009")
+    FORM_RUNNER_PUBLISH_URL = getenv("FORM_RUNNER_PUBLISH_URL", "http://form-runner:3009/publish")
     FORM_RUNNER_EXTERNAL_HOST = getenv(
         "FORM_RUNNER_EXTERNAL_HOST", "https://form-runner.communities.gov.localhost:3009"
     )

--- a/copilot/fsd-fund-application-builder/manifest.yml
+++ b/copilot/fsd-fund-application-builder/manifest.yml
@@ -139,12 +139,12 @@ environments:
       AUTHENTICATOR_HOST: "https://account.access-funding.communities.gov.uk"
       FLASK_ENV: production
       SENTRY_TRACES_SAMPLE_RATE: 1
-      # Prod points to UAT runner because prod runner does not support /publish endpoint needed for previewing forms
-      FORM_RUNNER_EXTERNAL_HOST: "https://application-questions.access-funding.uat.communities.gov.uk"
+      # Prod points to Test runner because prod runner does not support /publish endpoint needed for previewing forms
+      FORM_RUNNER_EXTERNAL_HOST: "https://application-questions.access-funding.test.communities.gov.uk"
       FORM_DESIGNER_EXTERNAL_HOST: "https://form-designer.access-funding.test.communities.gov.uk"
       # Internal host needs to be overridden with external host because the internal host points to the service running
-      # in the same AWS env and we are publishing from prod FAB to UAT Runner
-      FORM_RUNNER_INTERNAL_HOST: "https://application-questions.access-funding.uat.communities.gov.uk"
+      # in the same AWS env and we are publishing from prod FAB to Test Runner
+      FORM_RUNNER_INTERNAL_HOST: "https://application-questions.access-funding.test.communities.gov.uk"
     count:
       range: 2-4
       cooldown:

--- a/copilot/fsd-fund-application-builder/manifest.yml
+++ b/copilot/fsd-fund-application-builder/manifest.yml
@@ -47,7 +47,6 @@ variables:
   FUND_APPLICATION_BUILDER_HOST: "https://fund-application-builder.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
   AUTHENTICATOR_HOST: "https://account.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
   FLASK_ENV: ${COPILOT_ENVIRONMENT_NAME}
-  FORM_RUNNER_INTERNAL_HOST: "http://fsd-form-runner-adapter:3009"
   NOTIFICATION_SERVICE_HOST: http://fsd-notification:8080
   MAINTENANCE_MODE: false
   SENTRY_DSN: https://4128cfd691c439577e8f106968217f72@o1432034.ingest.us.sentry.io/4508496706666497
@@ -58,6 +57,7 @@ secrets:
   RSA256_PUBLIC_KEY_BASE64: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/RSA256_PUBLIC_KEY_BASE64
   SECRET_KEY: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/SECRET_KEY
   ALLOWED_DOMAINS: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/FAB_ALLOWED_DOMAINS
+  FORM_RUNNER_PUBLISH_URL: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/FORM_RUNNER_PUBLISH_URL
 
 # You can override any of the values defined above by environment.
 environments:
@@ -139,12 +139,9 @@ environments:
       AUTHENTICATOR_HOST: "https://account.access-funding.communities.gov.uk"
       FLASK_ENV: production
       SENTRY_TRACES_SAMPLE_RATE: 1
-      # Prod points to Test runner because prod runner does not support /publish endpoint needed for previewing forms
+      # Prod FAB points to Test Runner because Prod Runner doesn't support /publish endpoint needed for previewing forms
       FORM_RUNNER_EXTERNAL_HOST: "https://application-questions.access-funding.test.communities.gov.uk"
       FORM_DESIGNER_EXTERNAL_HOST: "https://form-designer.access-funding.test.communities.gov.uk"
-      # Internal host needs to be overridden with external host because the internal host points to the service running
-      # in the same AWS env and we are publishing from prod FAB to Test Runner
-      FORM_RUNNER_INTERNAL_HOST: "https://application-questions.access-funding.test.communities.gov.uk"
     count:
       range: 2-4
       cooldown:


### PR DESCRIPTION
### Ticket

[Tear down the UAT (or test?) environment](https://mhclgdigital.atlassian.net/browse/FSPT-342)

### Description

- **Preview forms using Form Runner in Test env not UAT**
We are wanting to remove the UAT environment as it is an unnecessary expense. We therefore need to decouple FAB in production from Form Runner in UAT so that when we remove UAT, FAB in production won't be affected in any way. Prod FAB is tied to UAT Runner because Prod Runner does not allow requests to the `/publish` endpoint required for previewing forms. This is intended as a temporary measure to unblock UAT environment shutdown. Longer-term we will look to link Prod FAB to Prod Runner.

- **Support Form Runner basic auth**
Form Runner is having basic auth added to it, as a compromise given we need to remove JWT auth from certain Runner endpoints to allow for cross-environment form publishing (Prod FAB -> Test Runner). Basic auth will create a dialogue box for credential entry from the user if the request to Runner originates from the browser, but in the case of backend requests (e.g., to `/publish`), we need to handle basic auth on the backend. The way we have chosen to implement this here is in line with existing precedents in Pre-Award and Post-Award - we hard-code the basic auth credentials in a URL we store in AWS Parameter Store (e.g., `http://username:password@example.com`) and then import that variable as a secret to swap directly into existing application code, with minimal changes required. We have chosen to use `FORM_RUNNER_PUBLISH_URL` from AWS because `FORM_RUNNER_INTERNAL_HOST` cannot be shared with Pre-Award - this is because in the AWS prod environment, Pre-Award needs to get rehydration tokens from Prod Runner, while FAB needs to publish to Test Runner. Plus `FORM_RUNNER_PUBLISH_URL` already exists for use by Form Designer anyway.

### What are the next steps?

Before we merge, we need to make sure `FORM_RUNNER_PUBLISH_URL` has been added to the AWS Parameter Store across all environments.

Longer-term... [Form Runner - Implement secure namespaced cache for Runner preview mode](https://mhclgdigital.atlassian.net/browse/FLS-1196) is a better solution. But this unblocks UAT teardown in the meantime.

### Linked PRs

[Digital Form Builder Adapter - Replace JWT auth with basic auth in pre-prod environments](https://github.com/communitiesuk/digital-form-builder-adapter/pull/178) - we need to deploy the Adapter PR _**BEFORE**_ the FAB PR. If we deploy the FAB PR first, then there will be a period where FAB sends users to a blocked endpoint on attempted form preview.