### PR TITLE
Start to retire the UAT environment

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -1,5 +1,5 @@
 name: Deploy to AWS
-run-name: ${{ github.event_name == 'workflow_dispatch' && format('Deploy to {0}', github.event.inputs.environment) || (github.ref == 'refs/heads/main' && 'Deploy to Test-UAT-Prod' || 'Build & Unit Test') }}
+run-name: ${{ github.event_name == 'workflow_dispatch' && format('Deploy to {0}', github.event.inputs.environment) || (github.ref == 'refs/heads/main' && 'Deploy to Test-Prod' || 'Build & Unit Test') }}
 
 on:
   workflow_dispatch:
@@ -11,7 +11,6 @@ on:
         options:
           - dev
           - test
-          - uat
           - prod
       run_e2e_tests:
         required: false
@@ -102,27 +101,6 @@ jobs:
     with:
       environment: 'test'
     secrets: inherit # pragma: allowlist secret
-
-  uat_deploy:
-    needs: [ test_e2e_test, paketo_build, setup ]
-    if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'uat') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') )}}
-    name: Deploy to UAT
-    concurrency:
-      group: deploy-uat
-      cancel-in-progress: false
-    uses: communitiesuk/funding-service-design-workflows/.github/workflows/standard-deploy.yml@main
-    secrets:
-      AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      SLACK_NOTIFICATION_CHANNEL_ID: ${{ secrets.SLACK_NOTIFICATION_CHANNEL_ID }}
-      SLACK_DEPLOYMENTS_CHANNEL_ID: ${{ secrets.SLACK_DEPLOYMENTS_CHANNEL_ID }}
-    with:
-      environment: uat
-      app_name: fund-application-builder
-      run_db_migrations: true
-      image_location: ${{ needs.paketo_build.outputs.image_location }}
-      notify_slack: true
-      notify_slack_on_deployment: false
 
   prod_deploy:
     needs: [ test_e2e_test, paketo_build, setup ]

--- a/copilot/fsd-fund-application-builder/addons/fsd-fund-application-builder-cluster.yml
+++ b/copilot/fsd-fund-application-builder/addons/fsd-fund-application-builder-cluster.yml
@@ -25,8 +25,6 @@ Mappings:
       "SecurityGroup": "sg-0b6c7aabb95bf14a9"
     test:
       "SecurityGroup": "sg-0cf75a004dbade7b8"
-    uat:
-      "SecurityGroup": "sg-04017abfef2079894"
     prod:
       "SecurityGroup": "sg-08cecea8f9b8a4ec9"
 

--- a/copilot/fsd-fund-application-builder/manifest.yml
+++ b/copilot/fsd-fund-application-builder/manifest.yml
@@ -99,38 +99,6 @@ environments:
       healthcheck:
         path: /healthcheck
         port: 8080
-  uat:
-    variables:
-      # UAT FAB deliberately points to Form Designer test environment.
-      FORM_DESIGNER_EXTERNAL_HOST: "https://form-designer.access-funding.test.communities.gov.uk"
-      SENTRY_TRACES_SAMPLE_RATE: 1
-    count:
-      range: 2-4
-      cooldown:
-        in: 60s
-        out: 30s
-      cpu_percentage:
-        value: 70
-      memory_percentage:
-        value: 80
-      requests: 30
-      response_time: 2s
-    sidecars:
-      nginx:
-        port: 8087
-        image:
-          location: xscys/nginx-sidecar-basic-auth
-        variables:
-          FORWARD_PORT: 8080
-          CLIENT_MAX_BODY_SIZE: 10m
-        secrets:
-          BASIC_AUTH_USERNAME: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_USERNAME
-          BASIC_AUTH_PASSWORD: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_PASSWORD
-    http:
-      target_container: nginx
-      healthcheck:
-        path: /healthcheck
-        port: 8080
   prod:
     http:
       alias: "fund-application-builder.access-funding.communities.gov.uk"


### PR DESCRIPTION
Ticket: https://mhclgdigital.atlassian.net/browse/FSPT-342

https://github.com/communitiesuk/funding-service-requests-for-comments/discussions/17

As per the conclusion of the above RFC, we're moving away from having three pipelined environments to two (test/prod) and a free-for-all pre-merge env (dev).

This patch removes all concepts of the UAT env from the app, but won't tear down the app instances themselves yet. We'll do this manually later when all of our services have been updated and the UAT env is disconnected from all pipelines/etc.