### PR TITLE
FLS-1327: Prevent KeyError when accessing 'maxWords'

### DIFF
--- a/app/all_questions/metadata_utils.py
+++ b/app/all_questions/metadata_utils.py
@@ -340,7 +340,10 @@ def determine_title_and_text_for_component(
             )
             if child["type"].casefold() in FIELD_TYPES_WITH_MAX_WORDS:
                 first_column_title = component["options"]["columnTitles"][0].casefold()
-                text.append(f"{child_title} (Max {child['options']['maxWords']} words per {first_column_title})")
+                options = child.get("options", {})
+                max_words = options.get("maxWords")
+                if max_words:
+                    text.append(f"{child_title} (Max {max_words} words per {first_column_title})")
             else:
                 text.append(child_title)
             text.extend(child_text)


### PR DESCRIPTION
### Ticket
https://mhclgdigital.atlassian.net/browse/FLS-1327

### Error
https://funding-service-design-team-dl.sentry.io/issues/6618237346/?alert_rule_id=15694520&alert_type=issue&notification_uuid=41230574-6767-4cc0-b814-c34c5f2b78f4&project=4508496706666497&referrer=slack

### Change description
- Fix: Prevent KeyError when accessing 'maxWords' in child['options']
- Used .get() method to safely access 'maxWords' from 'child["options"]', ensuring the code handles missing or empty 'options' dictionaries gracefully.

- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")