### PR TITLE
FLS-1353 - Adding hint text and placeholders for application round opening and closing time fields

### DIFF
--- a/app/blueprints/round/forms.py
+++ b/app/blueprints/round/forms.py
@@ -47,12 +47,20 @@ class RoundForm(FlaskForm):
     opens = DateTimeField(
         "Application round opens",
         widget=GovDatetimeInput(),
+        description=(
+            "Dates must be between Tuesday to Thursday (no bank holidays or weekends). The default time is midday - any"
+            " bespoke times must be during working hours (9am to 5pm)"
+        ),
         format="%d %m %Y %H %M",
         validators=[DataRequired(message="Enter the date and time the application round opens")],
     )
     deadline = DateTimeField(
         "Application round closes",
         widget=GovDatetimeInput(),
+        description=(
+            "Dates must be between Tuesday to Thursday (no bank holidays or weekends). The default time is midday - any"
+            " bespoke times must be during working hours (9am to 5pm)"
+        ),
         format="%d %m %Y %H %M",
         validators=[DataRequired(message="Enter the date and time the application round closes")],
     )

--- a/govuk_frontend_ext/fields.py
+++ b/govuk_frontend_ext/fields.py
@@ -28,6 +28,12 @@ class GovDatetimeInput(GovFormBase):
         elif field.data:
             day, month, year, hour, minute = field.data.strftime("%d %m %Y %H %M").split(" ")
 
+        if field.name in ["opens", "deadline"]:
+            if not hour:
+                hour = "12"
+            if not minute:
+                minute = "0"
+
         params.setdefault(
             "fieldset",
             {


### PR DESCRIPTION
### Ticket

[FAB - Application round opens and closes placeholders and hint text](https://mhclgdigital.atlassian.net/browse/FLS-1353)

### Description

Adds hint text and placeholder values to the "Application round opens" and "Application round closes" fields on the "Create a new application" page.

### Screenshots

![image](https://github.com/user-attachments/assets/0ffd9cda-6309-4789-8c6f-a48d7abad297)
