### PR TITLE
FLS-1401 - Adding descriptive labels to links

### DIFF
--- a/app/blueprints/application/templates/build_application.html
+++ b/app/blueprints/application/templates/build_application.html
@@ -41,16 +41,16 @@
                                 <span class="govuk-!-font-size-19 govuk-!-margin-right-2 disabled-link">Down</span>
                             {% else %}
                                 <a class="govuk-!-font-size-19 govuk-!-margin-right-2 govuk-link--no-visited-state"
-                                   href='{{ url_for("application_bp.move_section_down_route",round_id=round.round_id, section_id=section.section_id) }}'>Down</a>
+                                   href='{{ url_for("application_bp.move_section_down_route",round_id=round.round_id, section_id=section.section_id) }}'><span class="govuk-visually-hidden">Move {{ section.name_in_apply_json["en"] }} section </span>Down</a>
                             {% endif %}
                             {% if section.index == 1 %}
                                 <span class="govuk-!-font-size-19 govuk-!-margin-right-2 disabled-link">Up</span>
                             {% else %}
                                 <a class="govuk-!-font-size-19 govuk-!-margin-right-2 govuk-link--no-visited-state"
-                                   href='{{ url_for("application_bp.move_section_up_route",round_id=round.round_id, section_id=section.section_id) }}'>Up</a>
+                                   href='{{ url_for("application_bp.move_section_up_route",round_id=round.round_id, section_id=section.section_id) }}'><span class="govuk-visually-hidden">Move {{ section.name_in_apply_json["en"] }} section </span>Up</a>
                             {% endif %}
                             <a class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0"
-                               href='{{ url_for("application_bp.section", round_id=round.round_id, section_id=section.section_id) }}'>Edit</a>
+                               href='{{ url_for("application_bp.section", round_id=round.round_id, section_id=section.section_id) }}'>Edit<span class="govuk-visually-hidden"> {{ section.name_in_apply_json["en"] }} section</span></a>
                         {% endif %}
                     </span>
             </li>
@@ -68,7 +68,7 @@
                                 </h3>
                             </span>
                             <span class="app-task-list__task-actions">
-                                <a class="govuk-link--no-visited-state govuk-!-font-size-19" href="{{ url_for('application_bp.view_form_questions', round_id=round.round_id, section_id=section.section_id, form_id=form.form_id) }}">View questions</a>
+                                <a class="govuk-link--no-visited-state govuk-!-font-size-19" href="{{ url_for('application_bp.view_form_questions', round_id=round.round_id, section_id=section.section_id, form_id=form.form_id) }}">View questions<span class="govuk-visually-hidden"> for {{ form.name_in_apply_json["en"] }} form</span></a>
                             </span>
                         </li>
                     {% endfor %}

--- a/app/blueprints/application/templates/section.html
+++ b/app/blueprints/application/templates/section.html
@@ -60,16 +60,16 @@
                                         <span class="govuk-!-font-size-19 govuk-!-margin-right-2 disabled-link">Down</span>
                                     {% else %}
                                         <a class="govuk-!-font-size-19 govuk-!-margin-right-2 govuk-link--no-visited-state"
-                                            href="{{ url_for('application_bp.move_form_down_route', round_id=round_id, section_id=app_form.section_id, form_id=app_form.form_id) }}">Down</a>
+                                            href="{{ url_for('application_bp.move_form_down_route', round_id=round_id, section_id=app_form.section_id, form_id=app_form.form_id) }}"><span class="govuk-visually-hidden">Move {{ app_form.name_in_apply_json["en"] }} form </span>Down</a>
                                     {% endif %}
                                     {% if app_form.section_index == 1 %}
                                         <span class="govuk-!-font-size-19 govuk-!-margin-right-2 disabled-link">Up</span>
                                     {% else %}
                                         <a class="govuk-!-font-size-19 govuk-!-margin-right-2 govuk-link--no-visited-state"
-                                            href="{{ url_for('application_bp.move_form_up_route', round_id=round_id, section_id=app_form.section_id, form_id=app_form.form_id) }}">Up</a>
+                                            href="{{ url_for('application_bp.move_form_up_route', round_id=round_id, section_id=app_form.section_id, form_id=app_form.form_id) }}"><span class="govuk-visually-hidden">Move {{ app_form.name_in_apply_json["en"] }} form </span>Up</a>
                                     {% endif %}
                                     <a class="govuk-button govuk-button--secondary govuk-!-margin-left-2 govuk-!-margin-bottom-0"
-                                        href="{{ url_for('application_bp.delete_form', round_id=round_id, section_id=app_form.section_id, form_id=app_form.form_id) }}">Remove</a>
+                                        href="{{ url_for('application_bp.delete_form', round_id=round_id, section_id=app_form.section_id, form_id=app_form.form_id) }}">Remove<span class="govuk-visually-hidden"> {{ app_form.name_in_apply_json["en"] }} form</span></a>
                                 </span>
                             </li>
                         {% endfor %}

--- a/app/blueprints/round/templates/view_all_rounds.html
+++ b/app/blueprints/round/templates/view_all_rounds.html
@@ -49,7 +49,7 @@
         {% set action_link %}
         <a class='govuk-link govuk-link--no-visited-state'
         href='{{ url_for("application_bp.build_application", round_id=round.round_id) }}'>
-            {% if round.status == 'Complete' %}View application{% else %}Build application{% endif %}
+            {% if round.status == 'Complete' %}View application<span class="govuk-visually-hidden"> for {{ round.fund.title_json["en"] }} {{ round.title_json["en"] }}</span>{% else %}Build application<span class="govuk-visually-hidden"> for {{ round.fund.title_json["en"] }} {{ round.title_json["en"] }}</span>{% endif %}
         </a>
         {% endset %}
 

--- a/app/blueprints/template/templates/view_all_templates.html
+++ b/app/blueprints/template/templates/view_all_templates.html
@@ -69,7 +69,7 @@
         <a class='govuk-link govuk-link--no-visited-state'
         target="_blank"
         href='{{ url_for("index_bp.preview_form", form_id=form.form_id) }}'>
-            Preview in a new tab</a>
+            Preview <span class="govuk-visually-hidden">{{ form.template_name }} form</span> in a new tab</a>
         {% endset %}
 
         {% set table_rows.items = table_rows.items + [[

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,3 +1,4 @@
+from bs4 import BeautifulSoup, Tag
 from sqlalchemy import select
 
 from app.db import db
@@ -96,3 +97,12 @@ def submit_form(flask_test_client, url, data, follow_redirects=True):
     return flask_test_client.post(
         url, data=data, follow_redirects=follow_redirects, headers={"Content-Type": "application/x-www-form-urlencoded"}
     )
+
+
+def find_button_with_text(soup: BeautifulSoup, text: str, button_class: str | None = None) -> Tag | None:
+    """Find a button/link containing specific text, handling visually hidden content."""
+    buttons = soup.find_all("a", class_=button_class) if button_class else soup.find_all("a")
+    for button in buttons:
+        if text in button.get_text():
+            return button
+    return None

--- a/tests/unit/app/blueprints/application/test_routes.py
+++ b/tests/unit/app/blueprints/application/test_routes.py
@@ -7,7 +7,7 @@ from bs4 import BeautifulSoup
 from flask import g, url_for
 
 from app.blueprints.application.routes import create_export_zip
-from tests.helpers import submit_form
+from tests.helpers import find_button_with_text, submit_form
 
 
 @pytest.mark.usefixtures("set_auth_cookie", "patch_validate_token_rs256_allowed_domain_user")
@@ -87,7 +87,7 @@ def test_update_section_name(flask_test_client, seed_dynamic_data):
     data = {"name_in_apply_en": "section 1", "save_section": True}
     response = submit_form(flask_test_client, url, data, follow_redirects=True)
     soup = BeautifulSoup(response.data, "html.parser")
-    edit_section_link = soup.find("a", class_="govuk-button--secondary", string="Edit").get("href")
+    edit_section_link = find_button_with_text(soup, "Edit", "govuk-button--secondary").get("href")
     data = {
         "name_in_apply_en": "section updated",
         "save_section": True,
@@ -108,7 +108,7 @@ def test_delete_section(flask_test_client, seed_dynamic_data):
     data = {"name_in_apply_en": "section 1", "save_section": True}
     response = submit_form(flask_test_client, url, data, follow_redirects=True)
     soup = BeautifulSoup(response.data, "html.parser")
-    edit_section_link = soup.find("a", class_="govuk-button--secondary", string="Edit").get("href")
+    edit_section_link = find_button_with_text(soup, "Edit", "govuk-button--secondary").get("href")
     section_id = edit_section_link.split("/")[-1]
 
     delete_section_link = f"/rounds/{test_round.round_id}/sections/{section_id}/delete"
@@ -136,7 +136,7 @@ def test_update_section_empty_template_section_name(flask_test_client, seed_dyna
     data = {"name_in_apply_en": "section 1", "save_section": True}
     response = submit_form(flask_test_client, url, data, follow_redirects=True)
     soup = BeautifulSoup(response.data, "html.parser")
-    edit_section_link = soup.find("a", class_="govuk-button--secondary", string="Edit").get("href")
+    edit_section_link = find_button_with_text(soup, "Edit", "govuk-button--secondary").get("href")
     data = {"name_in_apply_en": "", "add_form": True, "section_id": edit_section_link.split("/")[-1], "template_id": ""}
 
     response = submit_form(flask_test_client, edit_section_link, data, follow_redirects=False)
@@ -167,7 +167,7 @@ def test_update_template_form(flask_test_client, seed_dynamic_data):
     data = {"name_in_apply_en": "section 1", "save_section": True}
     response = submit_form(flask_test_client, url, data, follow_redirects=True)
     soup = BeautifulSoup(response.data, "html.parser")
-    edit_section_link = soup.find("a", class_="govuk-button--secondary", string="Edit").get("href")
+    edit_section_link = find_button_with_text(soup, "Edit", "govuk-button--secondary").get("href")
     data = {
         "name_in_apply_en": "",
         "add_form": True,

--- a/tests/unit/app/blueprints/template/test_routes.py
+++ b/tests/unit/app/blueprints/template/test_routes.py
@@ -55,7 +55,9 @@ def test_generalized_table_template_with_existing_templates(flask_test_client):
     assert "Apply for funding to save an asset in your community" in html, (
         "Tasklist name and table component is missing"
     )
-    assert "Preview in a new tab" in html, "Preview action is missing"
+    assert 'Preview <span class="govuk-visually-hidden">asset-information form</span> in a new tab</a>' in html, (
+        "Preview action is missing"
+    )
 
 
 @pytest.mark.usefixtures("set_auth_cookie", "patch_validate_token_rs256_allowed_domain_user", "seed_dynamic_data")


### PR DESCRIPTION
### Ticket

[Add descriptive labels to links for screen reader users.](https://mhclgdigital.atlassian.net/browse/FLS-1401)

### Background

This is to help visually impaired users get an unambiguous understanding via their screen reader of which entity a link's action is referring to. We specifically looked for links on pages where the same link text is used again and again to support performing a particular action against multiple entities.

Unit tests needed to be updated as well because we can no longer use soup.find- the visually hidden text spans inside the <a> tags mean the tags' string attribute is now set to None, as per https://www.crummy.com/software/BeautifulSoup/bs4/doc/#string.

### Description of changes

- Adding visually hidden text to "Up" and "Down" links on the "Build application" and "Edit section" pages, so that they read "Move X $sectionName / $formName up / down" e.g., "Move Project details section Down"

- Adding visually hidden text to "Edit" links on the "Build application" page, so that they read "Edit $sectionName section"

- Adding visually hidden text to "Remove" links on the "Edit section" page, so that they read "Remove $formName form"

- Adding visually hidden text to "View / build application" links on the "View all rounds" page, so that they read "View / build application for $fundName $roundName" e.g., "View application for Test Fund Round 1"

- Adding visually hidden text to "Preview in a new tab" links on the "View all templates" page, so that they read "Preview $formName form in a new tab"

### Screenshots

**Up link** on "Build application" page

<img width="1586" height="657" alt="image" src="https://github.com/user-attachments/assets/a732e3f3-edc0-47c9-9688-2e6b9b08f7de" />

---

**Edit** link on "Build application" page

<img width="1590" height="713" alt="image" src="https://github.com/user-attachments/assets/071f7ee5-e5e3-489f-a335-18d53b0d0585" />

---

**Remove** link on "Edit section" page

<img width="1590" height="508" alt="image" src="https://github.com/user-attachments/assets/ffc44fb1-c094-46cf-b177-3cb589db05e4" />

---

**Build application** link on "View all rounds" page

<img width="1590" height="637" alt="image" src="https://github.com/user-attachments/assets/59ec331b-3442-49dc-8c16-1f42d0c86b9d" />

---

**Preview in a new tab** link on "View all templates" page

<img width="1591" height="637" alt="image" src="https://github.com/user-attachments/assets/ebdf4a53-218c-4d70-a097-f4f297e8d3c4" />