### PR TITLE
FLS-1422 [Blocked] Track user visited stated as requested by DAC to be compatible with accessibility

### DIFF
--- a/app/blueprints/application/templates/build_application.html
+++ b/app/blueprints/application/templates/build_application.html
@@ -60,7 +60,7 @@
                         <li class="app-task-list__item task-list__new-design">
                             <span class="app-task-list__task-name">
                                 <h3 class="govuk-body">
-                                    <a class="govuk-link govuk-link--no-visited-state"
+                                    <a class="govuk-link"
                                         target="_blank"
                                         href='{{ url_for("index_bp.preview_form", form_id=form.form_id) }}'>
                                         {{ form.name_in_apply_json["en"] }} (previews in a new tab)
@@ -68,7 +68,7 @@
                                 </h3>
                             </span>
                             <span class="app-task-list__task-actions">
-                                <a class="govuk-link--no-visited-state govuk-!-font-size-19" href="{{ url_for('application_bp.view_form_questions', round_id=round.round_id, section_id=section.section_id, form_id=form.form_id) }}">View questions<span class="govuk-visually-hidden"> for {{ form.name_in_apply_json["en"] }} form</span></a>
+                                <a class="govuk-!-font-size-19" href="{{ url_for('application_bp.view_form_questions', round_id=round.round_id, section_id=section.section_id, form_id=form.form_id) }}">View questions<span class="govuk-visually-hidden"> for {{ form.name_in_apply_json["en"] }} form</span></a>
                             </span>
                         </li>
                     {% endfor %}

--- a/app/blueprints/fund/templates/view_all_funds.html
+++ b/app/blueprints/fund/templates/view_all_funds.html
@@ -33,7 +33,7 @@
     {% set table_rows = namespace(items=[]) %}
     {% for fund in pagination.items %}
     {% set fund_detail_link %}
-    <a class='govuk-link govuk-link--no-visited-state'
+    <a class='govuk-link'
        href={{ url_for("fund_bp.view_fund_details", fund_id=fund.fund_id) }}>{{ fund.name_json["en"] }}</a>
     {% endset %}
     {% set table_rows.items = table_rows.items + [

--- a/app/blueprints/index/templates/dashboard.html
+++ b/app/blueprints/index/templates/dashboard.html
@@ -12,7 +12,7 @@
             <ol class="govuk-list govuk-!-margin-bottom-7">
                 <li>
                     <p class="govuk-body govuk-!-margin-bottom-0">
-                        <a class="govuk-link govuk-!-font-weight-bold govuk-link--no-visited-state"
+                        <a class="govuk-link govuk-!-font-weight-bold"
                            href="{{ url_for('fund_bp.create_fund') }}">1. Add a new grant</a>
                     </p>
                     <p class="govuk-body">
@@ -21,7 +21,7 @@
                 </li>
                 <li>
                     <p class="govuk-body govuk-!-margin-bottom-0">
-                        <a class="govuk-link govuk-!-font-weight-bold govuk-link--no-visited-state"
+                        <a class="govuk-link govuk-!-font-weight-bold"
                            href="{{ url_for('round_bp.select_fund', action="return_home") }}">2. Set up a new application</a>
                     </p>
                     <p class="govuk-body">
@@ -30,7 +30,7 @@
                 </li>
                 <li>
                     <p class="govuk-body govuk-!-margin-bottom-0">
-                        <a class="govuk-link govuk-!-font-weight-bold govuk-link--no-visited-state"
+                        <a class="govuk-link govuk-!-font-weight-bold"
                            href="{{ url_for('application_bp.select_fund') }}">3. Design your application</a>
                     </p>
                     <p class="govuk-body">
@@ -45,7 +45,7 @@
                 questions if needed.
             </p>
             <p class="govuk-body">
-                <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('template_bp.view_templates') }}">View
+                <a class="govuk-link" href="{{ url_for('template_bp.view_templates') }}">View
                     and create templates</a>
             </p>
         </div>

--- a/app/blueprints/round/templates/view_all_rounds.html
+++ b/app/blueprints/round/templates/view_all_rounds.html
@@ -35,7 +35,7 @@
         {% for round in pagination.items %}
 
         {% set round_detail_link %}
-        <a class='govuk-link govuk-link--no-visited-state'
+        <a class='govuk-link'
            href='{{ url_for("round_bp.round_details", round_id=round.round_id) }}'>
             Apply for {{ round.fund.title_json["en"] }}</a>
         {% endset %}
@@ -47,7 +47,7 @@
         {% endset %}
 
         {% set action_link %}
-        <a class='govuk-link govuk-link--no-visited-state'
+        <a class='govuk-link'
         href='{{ url_for("application_bp.build_application", round_id=round.round_id) }}'>
             {% if round.status == 'Complete' %}View application<span class="govuk-visually-hidden"> for {{ round.fund.title_json["en"] }} {{ round.title_json["en"] }}</span>{% else %}Build application<span class="govuk-visually-hidden"> for {{ round.fund.title_json["en"] }} {{ round.title_json["en"] }}</span>{% endif %}
         </a>

--- a/app/blueprints/template/templates/view_all_templates.html
+++ b/app/blueprints/template/templates/view_all_templates.html
@@ -61,12 +61,12 @@
         {% for form in pagination.items %}
 
         {% set form_link %}
-        <a class='govuk-link govuk-link--no-visited-state'
+        <a class='govuk-link'
            href='{{ url_for('template_bp.template_details', form_id=form.form_id) }}'>{{ form.template_name }}</a>
         {% endset %}
 
         {% set form_preview_link %}
-        <a class='govuk-link govuk-link--no-visited-state'
+        <a class='govuk-link'
         target="_blank"
         href='{{ url_for("index_bp.preview_form", form_id=form.form_id) }}'>
             Preview <span class="govuk-visually-hidden">{{ form.template_name }} form</span> in a new tab</a>


### PR DESCRIPTION
**Ticket: [[FAB] Style visited links to help users track their navigation history.](https://mhclgdigital.atlassian.net/browse/FLS-1422)**


### Change description

Users are currently unable to visually identify visited links across the application. The `govuk-link--no-visited-state` class suppresses default browser behavior for visited link styling, impacting cognitive users' ability to retrace their navigation history.

**Current behavior:**

All links appear the same regardless of whether they’ve been visited.

**Expected behavior:**

Visited links should appear with a visually distinct style (e.g. purple or other default visited color) to support cognitive accessibility and orientation.

**Solution:**

Removed the `govuk-link--no-visited-state` class from all relevant link elements to restore native visited link styling.

- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

### Screenshots of UI changes (if applicable)
<img width="1488" height="1322" alt="image" src="https://github.com/user-attachments/assets/d5cd7eb0-01fa-430b-b60b-d125cb4b3344" />

<img width="1488" height="1322" alt="image" src="https://github.com/user-attachments/assets/e0cd8cef-9cc0-4645-bd8f-f712779aaf46" />
