### PR TITLE
Fix screen reader accessibility issue with "Apply for" prefix

### DIFF
--- a/app/blueprints/fund/forms.py
+++ b/app/blueprints/fund/forms.py
@@ -49,13 +49,13 @@ class FundForm(FlaskForm):
     title_en = StringField(
         "Application name",
         widget=GovTextInput(),
-        description="For example, Apply for funding to save an asset in your community",
+        description="For example, funding to save an asset in your community",
         validators=[DataRequired(message="Enter the application name")],
     )
     title_cy = StringField(
         "Application name (Welsh)",
         widget=GovTextInput(),
-        description="For example, Apply for funding to save an asset in your community",
+        description="For example, funding to save an asset in your community",
     )
     description_en = TextAreaField(
         "Grant description",

--- a/tests/unit/app/blueprints/template/test_routes.py
+++ b/tests/unit/app/blueprints/template/test_routes.py
@@ -52,9 +52,7 @@ def test_generalized_table_template_with_existing_templates(flask_test_client):
     assert '<th scope="col" class="govuk-table__header">Task name</th>' in html, "Tasklist Name header missing"
     assert '<th scope="col" class="govuk-table__header"></th>' in html, "Action header missing"
     assert "asset-information" in html, "Template name is missing"
-    assert "Apply for funding to save an asset in your community" in html, (
-        "Tasklist name and table component is missing"
-    )
+    assert "funding to save an asset in your community" in html, "Tasklist name and table component is missing"
     assert 'Preview <span class="govuk-visually-hidden">asset-information form</span> in a new tab</a>' in html, (
         "Preview action is missing"
     )


### PR DESCRIPTION
### Ticket

[Ensure visually hidden prefix text is accessible to screen readers or remove it from the example input.](https://mhclgdigital.atlassian.net/browse/FLS-1416)

### Problem

  The "Application name" field on /grants/create had duplicate "Apply for" text for screen reader users:
  
  - Visual prefix shows "Apply for" (hidden from screen readers with aria-hidden="true")
  - Field description said "For example, Apply for funding to save an asset..."
  - Screen readers heard the description but not the prefix, causing potential duplication
  
### Solution
  Removed "Apply for" from field descriptions to prevent duplication.
  
  Before: "For example, Apply for funding to save an asset in your community"
  After: "For example, funding to save an asset in your community"


  Visual users see no change, screen reader users no longer get duplicate "Apply for" text, fixing accessibility issue  DAC_Info_And_Relationships_03.

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)

<img width="1005" height="168" alt="Screenshot 2025-07-30 at 13 03 24" src="https://github.com/user-attachments/assets/ed2ff596-e30e-41c3-b625-de51f29d3de6" />

