### PR TITLE
Allow one hashed inline style (keep style-src strict)

### DIFF
--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -44,7 +44,7 @@ class DefaultConfig(object):
     SECURE_CSP = {
         "default-src": "'self'",
         "script-src": ["'self'"],  # Needed to enable nonce
-        "style-src": ["'self'"],
+        "style-src": ["'self'", "'unsafe-hashes'", "'sha256-9/aFFbAwf+Mwl6MrBQzrJ/7ZK5vo7HdOUR7iKlBk78U='"],
     }
 
     # Talisman Config


### PR DESCRIPTION

### Change description
Updates the CSP style-src to `['self', 'unsafe-hashes', 'sha256-9/aFFbAwf+Mwl6MrBQzrJ/7ZK5vo7HdOUR7iKlBk78U=']`. This keeps styles limited to our origin while permitting exactly one inline style (the one matching the SHA-256 hash) without using unsafe-inline. If that inline style changes, the hash must be updated.
