### PR TITLE
FLS-1462 - Update interfaces for insert and update form functions

### DIFF
--- a/app/blueprints/template/routes.py
+++ b/app/blueprints/template/routes.py
@@ -131,10 +131,8 @@ def edit_template(form_id):
     if form.validate_on_submit():
         updated_form = update_form(
             form_id=form_id,
-            new_form_config={
-                "name_in_apply_json": {"en": form.tasklist_name.data},
-                "template_name": form.template_name.data,
-            },
+            form_name=form.tasklist_name.data,
+            template_name=form.template_name.data,
         )
         if form.file and form.file.data is not None:
             delete_form(form_id=form_id, cascade=True)

--- a/app/db/queries/application.py
+++ b/app/db/queries/application.py
@@ -181,27 +181,21 @@ def insert_new_form(
     return form
 
 
-def update_form(form_id, new_form_config):
+def update_form(
+    form_id: UUID,
+    form_name: str,  # Name as it appears in the Apply tasklist
+    template_name: str,  # Our own internal name for the template
+):
     form = db.session.query(Form).where(Form.form_id == form_id).one_or_none()
     if form:
-        # Define a list of allowed keys to update
-        allowed_keys = [
-            "section_id",
-            "name_in_apply_json",
-            "template_name",
-            "is_template",
-            "audit_info",
-            "section_index",
-            "runner_publish_name",
-        ]
-
-        # Iterate over the new_form_config dictionary
-        for key, value in new_form_config.items():
-            # Update the form if the key is allowed
-            if key in allowed_keys:
-                setattr(form, key, value)
-
-        db.session.commit()
+        form.name_in_apply_json = {"en": form_name}
+        form.template_name = template_name
+        try:
+            db.session.commit()
+        except SQLAlchemyError as e:
+            db.session.rollback()
+            current_app.logger.error(e)
+            raise e
     return form
 
 

--- a/app/db/queries/application.py
+++ b/app/db/queries/application.py
@@ -1,7 +1,9 @@
 from uuid import UUID, uuid4
 
+from flask import current_app
 from flask_sqlalchemy.pagination import Pagination
 from sqlalchemy import String, cast, delete, select
+from sqlalchemy.exc import SQLAlchemyError
 
 from app.db import db
 from app.db.models import Component, Condition, Form, FormSection, Lizt, Page, PageCondition, Section
@@ -153,42 +155,28 @@ def delete_section(section_id, cascade: bool = False):
 
 
 # CRUD FORM
-def insert_new_form(new_form_config):
-    """
-    Inserts a form object based on the provided configuration.
-
-    Parameters:
-        new_form_config (dict): A dictionary containing the configuration for the new form.
-            new_form_config keys:
-                - section_id (str): The ID of the section to which the form belongs.
-                - name_in_apply_json (dict): The name of the form as it will be in the Application
-                JSON (support multiple languages/keys).
-                - is_template (bool): A flag indicating whether the form is a template.
-                - template_name (str): The name of the template.
-                - source_template_id (str): The ID of the source template.
-                - audit_info (dict): Audit information for the form.
-                - section_index (int): The index of the form within the section.
-                - runner_publish_name (bool): The path of the form in the form runner (kebab case).
-    Returns:
-        Form: The newly created form object.
-    """
-
+def insert_new_form(
+    form_name: str,  # Name as it appears in the Apply tasklist
+    template_name: str,  # Our own internal name for the template
+    runner_publish_name: str,  # Unique URL-friendly identifier used in request to Form Runner
+) -> Form:
     form = Form(
         form_id=uuid4(),
-        section_id=new_form_config.get("section_id", None),
-        name_in_apply_json=new_form_config.get("name_in_apply_json"),
-        is_template=new_form_config.get("is_template", False),
-        template_name=new_form_config.get("template_name", None),
-        source_template_id=new_form_config.get("source_template_id", None),
-        audit_info=new_form_config.get("audit_info", {}),
-        section_index=new_form_config.get("section_index"),
-        runner_publish_name=new_form_config.get("runner_publish_name", None),
+        section_id=None,
+        name_in_apply_json={"en": form_name},
+        is_template=True,
+        template_name=template_name,
+        source_template_id=None,
+        audit_info=None,
+        section_index=None,
+        runner_publish_name=runner_publish_name,
     )
     try:
         db.session.add(form)
         db.session.commit()
-    except Exception as e:
-        print(e)
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        current_app.logger.error(e)
         raise e
     return form
 

--- a/app/import_config/load_form_json.py
+++ b/app/import_config/load_form_json.py
@@ -243,17 +243,9 @@ def insert_form_as_template(form, template_name=None, filename=None):
         template_name = filename.split(".")[0]
 
     new_form = insert_new_form(
-        {
-            "section_id": None,
-            "name_in_apply_json": {"en": form_name},
-            "template_name": template_name,
-            "is_template": True,
-            "audit_info": None,
-            "section_index": None,
-            "runner_publish_name": human_to_kebab_case(filename.split(".")[0]).lower(),
-            "source_template_id": None,
-            "form_json": form,
-        }
+        form_name=form_name,
+        template_name=template_name,
+        runner_publish_name=human_to_kebab_case(filename.split(".")[0]).lower(),
     )
 
     return new_form

--- a/tests/unit/app/blueprints/template/test_routes.py
+++ b/tests/unit/app/blueprints/template/test_routes.py
@@ -207,10 +207,8 @@ def test_edit_template_post_update_without_actions(
         assert response.status_code == 200
         mock_update_form.assert_called_once_with(
             form_id=form_mock_id,
-            new_form_config={
-                "name_in_apply_json": {"en": "Updated Tasklist"},
-                "template_name": "Updated Template",
-            },
+            form_name="Updated Tasklist",
+            template_name="Updated Template",
         )
         mock_flash_message.assert_called_with("Template updated")
 
@@ -244,10 +242,8 @@ def test_edit_template_post_update_with_actions_template_table(
         assert response.status_code == 200
         mock_update_form.assert_called_once_with(
             form_id=form_mock_id,
-            new_form_config={
-                "name_in_apply_json": {"en": "Updated Tasklist"},
-                "template_name": "Updated Template",
-            },
+            form_name="Updated Tasklist",
+            template_name="Updated Template",
         )
         mock_redirect.assert_called_once_with("/templates")
 

--- a/tests/unit/app/db/queries/test_application.py
+++ b/tests/unit/app/db/queries/test_application.py
@@ -175,25 +175,19 @@ def test_insert_new_form(flask_test_client, _db, clear_test_data, seed_dynamic_d
 
 
 def test_update_form(flask_test_client, _db, clear_test_data, seed_dynamic_data, test_form: Form):
-    round_id = seed_dynamic_data["rounds"][0].round_id
-    new_section_config["round_id"] = round_id
-    new_section = insert_new_section(new_section_config)
-    test_form.section_id = new_section.section_id
+    assert test_form.name_in_apply_json == {"en": "Test form name"}
+    assert test_form.template_name == "Test template name"
+    assert test_form.runner_publish_name == "test-template-name"
 
-    updated_form_config = {
-        "section_id": new_section.section_id,
-        "name_in_apply_json": {"en": "Updated form name"},
-        "is_template": False,
-        "audit_info": {"created_by": "John Doe", "created_at": "2022-01-01"},
-        "section_index": 1,
-        "runner_publish_name": "updated-test-form",
-    }
-    updated_form = update_form(test_form.form_id, updated_form_config)
+    updated_form: Form = update_form(
+        form_id=test_form.form_id,
+        form_name="Updated form name",
+        template_name="Updated template name",
+    )
 
-    assert isinstance(updated_form, Form)
-    assert updated_form.section_id == updated_form_config["section_id"]
-    assert updated_form.name_in_apply_json == updated_form_config["name_in_apply_json"]
-    assert updated_form.audit_info == updated_form_config["audit_info"]
+    assert updated_form.form_id == test_form.form_id
+    assert updated_form.name_in_apply_json == {"en": "Updated form name"}
+    assert updated_form.template_name == "Updated template name"
 
 
 def test_delete_form(flask_test_client, _db, clear_test_data, seed_dynamic_data, test_form: Form):


### PR DESCRIPTION
### 🎫 Ticket

[Update interfaces for insert and update form functions](https://mhclgdigital.atlassian.net/browse/FLS-1462)

### ♻️ Changes

**Commit 1 - Adjusting insert_new_form function interface**

Currently, `insert_new_form` takes an arg `new_form_config` which is an untyped dict with an implicit schema. `insert_new_form` is only called in one place (`insert_form_template` in `app.import_config.load_form_json`) and there we pass static values for five of the nine dict keys.

This commit simplifies and normalises the interface of `insert_new_form`, passing specific args instead of a schema-less dict.

**Commit 2 - Adjusting update_form function interface**

Currently, `update_form` takes an arg `new_form_config` which is an untyped dict with an implicit schema. `update_form` is only called in one place (`edit_template` in `app.blueprints.template.routes`) and there we pass only two dict values.
    
This commit simplifies and normalises the interface of `update_form`, passing specific args instead of a schema-less dict.

### 🚧 Testing

- Tests updated in `tests.unit.app.db.queries.test_application` module