### PR TITLE
Don't add filename to form JSON until after it's been inserted into form_json column

### DIFF
--- a/app/import_config/load_form_json.py
+++ b/app/import_config/load_form_json.py
@@ -286,9 +286,9 @@ def load_form_jsons(override_fund_config=None):
 def load_json_from_file(data, template_name, filename):
     db = app.extensions["sqlalchemy"]
     try:
-        data["filename"] = human_to_kebab_case(template_name)
         inserted_form = insert_form_as_template(data, template_name=template_name, filename=filename)
         db.session.flush()  # flush to get the form id
+        data["filename"] = filename
         insert_form_config(data, inserted_form.form_id)
         db.session.commit()
         return inserted_form


### PR DESCRIPTION
There is a bug whereby we are adding `filename` to the form JSON after validation but before we store the JSON in the `form_json` column. `filename` is a key rejected by the Form Runner. Thus the addition of this key invalidates the JSON.

In this PR, we move the addition of the filename to the dict to after the insertion of the form JSON in the database, to avoid this issue with minimal code changes.