### PR TITLE
Start using whole form JSON for form preview

### DIFF
--- a/app/blueprints/index/routes.py
+++ b/app/blueprints/index/routes.py
@@ -46,7 +46,7 @@ def preview_form(form_id):
     'runner_publish_name' of that form. Returns a redirect to that form in the form-runner
     """
     form = get_form_by_id(form_id)
-    form_json = build_form_json(form)
+    form_json = form.form_json
     form_id = form.runner_publish_name
 
     try:


### PR DESCRIPTION
### Ticket

[Start using whole form JSON for form preview 
](https://mhclgdigital.atlassian.net/browse/FLS-1464)


### Change description
  
When we preview a form in the Form Runner (see the preview_form endpoint in app.blueprints.index.routes), we re-build the form JSON at runtime from the set of relational entities we decomposed the JSON file down into at import. Put another way, we call the build_form_json function. 

Now we're directly using form_json as we are storing form_josn in the Form table. Instead of build_form_json now it's form.form_json to make it simple.


- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

