### PR TITLE
FLS-1466 - Start using whole form JSON for forms export

### DIFF
--- a/app/export_config/generate_fund_round_form_jsons.py
+++ b/app/export_config/generate_fund_round_form_jsons.py
@@ -3,9 +3,7 @@ import json
 from flask import current_app
 from jsonschema import ValidationError
 
-from app.db.queries.fund import get_fund_by_id
 from app.db.queries.round import get_round_by_id
-from app.export_config.generate_form import build_form_json
 from app.export_config.helpers import write_config
 from app.shared.json_validation import validate_form_json
 
@@ -27,11 +25,10 @@ def generate_form_jsons_for_round(round_id, base_output_dir=None):
     if not round_id:
         raise ValueError("Round ID is required to generate form JSONs.")
     round = get_round_by_id(round_id)
-    fund = get_fund_by_id(round.fund_id)
     current_app.logger.info("Generating form JSONs for round {round_id}", extra=dict(round_id=round_id))
     for section in round.sections:
         for form in section.forms:
-            result = build_form_json(form=form, fund_title=fund.title_json["en"])
+            result = form.form_json
             form_json = json.dumps(result, indent=4)
             try:
                 validate_form_json(result)

--- a/app/import_config/load_form_json.py
+++ b/app/import_config/load_form_json.py
@@ -275,8 +275,8 @@ def load_form_jsons(override_fund_config=None):
             form_configs = override_fund_config
         for form_config in form_configs:
             # prepare all row commits
-            inserted_form = insert_form_as_template(form_config, None, form_config["filename"])
-            inserted_pages, inserted_components = insert_form_config(form_config, inserted_form.form_id)
+            inserted_form = insert_form_as_template(form_config["form_json"], None, form_config["filename"])
+            inserted_pages, inserted_components = insert_form_config(form_config["form_json"], inserted_form.form_id)
     except Exception as e:
         print(e)
         db.session.rollback()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,8 +80,11 @@ def db_with_templates(app, _db):
         if os.path.exists(file_path):
             with open(file_path, "r") as json_file:
                 input_form = json.load(json_file)
-                input_form["filename"] = "asset-information"
-                form_configs.append(input_form)
+                form_config = {
+                    "filename": "asset-information",
+                    "form_json": input_form,
+                }
+                form_configs.append(form_config)
         load_form_jsons(form_configs)
     yield _db
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -28,8 +28,11 @@ def test_generate_config_to_verify_form_sections(
     file_path = Path("tests") / "test_data" / input_filename
     with open(file_path, "r") as json_file:
         input_form = json.load(json_file)
-        input_form["filename"] = input_filename
-        form_configs.append(input_form)
+        form_config = {
+            "filename": input_filename,
+            "form_json": input_form,
+        }
+        form_configs.append(form_config)
     load_form_jsons(form_configs)
 
     round_id = seed_dynamic_data["rounds"][0].round_id
@@ -58,7 +61,7 @@ def test_generate_config_to_verify_form_sections(
     with open(generated_json_form, "r") as file:
         output_form = json.load(file)
 
-    assert len(output_form["sections"]) == len(form_configs[0]["sections"])
+    assert len(output_form["sections"]) == len(form_configs[0]["form_json"]["sections"])
 
 
 @pytest.mark.parametrize(
@@ -97,8 +100,11 @@ def test_generate_config_for_round_valid_input(
     file_path = Path("tests") / "test_data" / input_filename
     with open(file_path, "r") as json_file:
         input_form = json.load(json_file)
-        input_form["filename"] = input_filename
-        form_configs.append(input_form)
+        form_config = {
+            "filename": input_filename,
+            "form_json": input_form,
+        }
+        form_configs.append(form_config)
     load_form_jsons(form_configs)
 
     expected_form_count = 1

--- a/tests/seed_test_data.py
+++ b/tests/seed_test_data.py
@@ -76,6 +76,131 @@ page_five_id = uuid4()
 alt_page_id = uuid4()
 
 
+ABOUT_YOUR_ORG_FORM_JSON = {
+    "startPage": "/organisation-name",
+    "pages": [
+        {
+            "path": "/organisation-name",
+            "title": "Organisation Name",
+            "components": [
+                {
+                    "name": "organisation_name",
+                    "options": {"hideTitle": False, "classes": ""},
+                    "type": "TextField",
+                    "title": "What is your organisation's name?",
+                    "hint": "This must match the registered legal organisation name",
+                    "schema": {},
+                }
+            ],
+            "next": [{"path": "/organisation-alternative-names"}],
+        },
+        {
+            "path": "/organisation-alternative-names",
+            "title": "Alternative names of your organisation",
+            "components": [
+                {"name": "alt_name_1", "options": {}, "type": "TextField", "title": "Alternative name 1", "schema": {}}
+            ],
+            "next": [{"path": "/organisation-address"}],
+        },
+        {
+            "path": "/organisation-address",
+            "title": "Organisation Address",
+            "components": [
+                {
+                    "name": "organisation_address",
+                    "options": {},
+                    "type": "UkAddressField",
+                    "title": "What is your organisation's address?",
+                    "schema": {},
+                }
+            ],
+            "next": [{"path": "/organisation-classification"}],
+        },
+        {
+            "path": "/organisation-classification",
+            "title": "Organisation Classification",
+            "components": [
+                {
+                    "name": "organisation_classification",
+                    "options": {"hideTitle": False, "classes": ""},
+                    "type": "RadiosField",
+                    "title": "How is your organisation classified?",
+                    "list": "classifications_list",
+                    "schema": {},
+                }
+            ],
+            "next": [{"path": "/summary"}],
+        },
+        {
+            "path": "/summary",
+            "title": "Check your answers",
+            "components": [],
+            "next": [],
+            "controller": "./pages/summary.js",
+        },
+    ],
+    "lists": [
+        {
+            "name": "classifications_list",
+            "type": "string",
+            "items": [{"text": "Charity", "value": "charity"}, {"text": "Public Limited Company", "value": "plc"}],
+        }
+    ],
+    "conditions": [],
+    "sections": [],
+    "outputs": [],
+    "skipSummary": False,
+    "name": "About your organisation",
+}
+
+CONTACT_DETAILS_FORM_JSON = {
+    "startPage": "/lead-contact-details",
+    "pages": [
+        {
+            "path": "/lead-contact-details",
+            "title": "Lead Contact Details",
+            "components": [
+                {
+                    "name": "lead_contact_name",
+                    "options": {},
+                    "type": "TextField",
+                    "title": "Lead contact full name",
+                    "schema": {},
+                },
+                {
+                    "name": "lead_contact_email",
+                    "options": {},
+                    "type": "EmailAddressField",
+                    "title": "Lead contact email address",
+                    "schema": {},
+                },
+                {
+                    "name": "lead_contact_phone",
+                    "options": {},
+                    "type": "TelephoneNumberField",
+                    "title": "Lead contact telephone number",
+                    "schema": {},
+                },
+            ],
+            "next": [{"path": "/summary"}],
+        },
+        {
+            "path": "/summary",
+            "title": "Check your answers",
+            "components": [],
+            "next": [],
+            "controller": "./pages/summary.js",
+        },
+    ],
+    "lists": [],
+    "conditions": [],
+    "sections": [],
+    "outputs": [],
+    "skipSummary": False,
+    "name": "Contact Details",
+}
+
+
 # NOSONAR Ignore since this data is related to unit tests
 def init_salmon_fishing_fund():
     organisation_uuid = uuid4()
@@ -125,6 +250,7 @@ def init_salmon_fishing_fund():
         name_in_apply_json={"en": "About your organisation"},
         section_index=1,
         runner_publish_name="about-your-org",
+        form_json=ABOUT_YOUR_ORG_FORM_JSON,
     )
     f2: Form = Form(
         form_id=uuid4(),
@@ -132,6 +258,7 @@ def init_salmon_fishing_fund():
         name_in_apply_json={"en": "Contact Details"},
         section_index=2,
         runner_publish_name="contact-details",
+        form_json=CONTACT_DETAILS_FORM_JSON,
     )
     p1: Page = Page(
         page_id=page_one_id,
@@ -424,16 +551,7 @@ def init_unit_test_data() -> dict:
         section_index=1,
         runner_publish_name="about-your-org",
         template_name="About your organization template",
-        form_json={
-            "name": "Minimal Form",
-            "startPage": "/start",
-            "sections": [],
-            "pages": [{"path": "/start", "title": "Start Page", "components": [], "next": []}],
-            "lists": [],
-            "conditions": [],
-            "outputs": [],
-            "skipSummary": False,
-        },
+        form_json=ABOUT_YOUR_ORG_FORM_JSON,
     )
     p1: Page = Page(
         page_id=uuid4(),
@@ -567,6 +685,7 @@ def fund_without_assessment() -> dict:
         section_index=1,
         runner_publish_name="about-your-org",
         template_name="About your organization template",
+        form_json=ABOUT_YOUR_ORG_FORM_JSON,
     )
 
     f2_r1_s1_f2: Form = Form(
@@ -576,6 +695,7 @@ def fund_without_assessment() -> dict:
         section_index=1,
         runner_publish_name="about-your-org",
         template_name="About your organization template",
+        form_json=ABOUT_YOUR_ORG_FORM_JSON,
     )
 
     f2_r1_s1_f1_p1: Page = Page(

--- a/tests/test_data/org-info.json
+++ b/tests/test_data/org-info.json
@@ -1245,5 +1245,6 @@
   },
   "phaseBanner": {
     "phase": "beta"
-  }
+  },
+  "name": "Organisation info"
 }

--- a/tests/unit/app/blueprints/template/test_routes.py
+++ b/tests/unit/app/blueprints/template/test_routes.py
@@ -289,7 +289,7 @@ def test_template_questions_view(flask_test_client, seed_dynamic_data):
     # Title component availability check
     assert "About your organization template" in html, "Template title is missing"
     assert "This template contains the following questions." in html, "Title description is missing"
-    assert "Start Page" in html, "Page title is missing"
+    assert "Organisation Name" in html, "Page title is missing"
 
 
 @pytest.mark.usefixtures("set_auth_cookie", "patch_validate_token_rs256_allowed_domain_user")

--- a/tests/unit/app/export_config/test_generate_fund_round_form_jsons.py
+++ b/tests/unit/app/export_config/test_generate_fund_round_form_jsons.py
@@ -14,84 +14,96 @@ def test_generate_form_jsons_for_round_valid_input(seed_dynamic_data, temp_outpu
     # Execute: Call the function with valid inputs
     generate_form_jsons_for_round(round_id)
     # Assert: Check if the directory structure and files are created as expected
-    expected_files = [
-        {
-            "path": temp_output_dir / round_short_name / "form_runner" / f"{form_publish_name}.json",
-            "expected_output": {
-                "startPage": "/intro-about-your-organisation",
-                "pages": [
-                    {
-                        "path": "/organisation-name",
-                        "title": "Organisation Name",
-                        "components": [
-                            {
-                                "options": {"hideTitle": False, "classes": ""},
-                                "type": "TextField",
-                                "title": "What is your organisation's name?",
-                                "hint": "This must match the registered legal organisation name",
-                                "schema": {},
-                                "name": "organisation_name",
-                            },
-                            {
-                                "options": {"hideTitle": False, "classes": ""},
-                                "type": "RadiosField",
-                                "title": "How is your organisation classified?",
-                                "hint": "",
-                                "schema": {},
-                                "name": "organisation_classification",
-                                "list": "classifications_list",
-                                "values": {"type": "listRef"},
-                            },
-                        ],
-                        "next": [{"path": "/summary"}],
-                    },
-                    {
-                        "path": "/intro-about-your-organisation",
-                        "title": "About your organisation",
-                        "components": [
-                            {
-                                "name": "start-page-content",
-                                "options": {},
-                                "type": "Html",
-                                "content": '<p class="govuk-body"></p><p class="govuk-body">'
-                                "We will ask you about:</p> <ul><li>Organisation Name</li></ul>",
-                                "schema": {},
-                            }
-                        ],
-                        "next": [{"path": "/organisation-name"}],
-                        "controller": "./pages/start.js",
-                    },
-                    {
-                        "path": "/summary",
-                        "title": "Check your answers",
-                        "components": [],
-                        "next": [],
-                        "section": "uLwBuz",
-                        "controller": "./pages/summary.js",
-                    },
-                ],
-                "lists": [
-                    {
-                        "type": "string",
-                        "items": [
-                            {"text": "Charity", "value": "charity"},
-                            {"text": "Public Limited Company", "value": "plc"},
-                        ],
-                        "name": "classifications_list",
-                        "title": None,
-                    }
-                ],
-                "conditions": [],
-                "sections": [],
-                "outputs": [],
-                "skipSummary": False,
-                "name": "Apply for funding to improve testing",
-            },
-        }
-    ]
-    for expected_file in expected_files:
-        path = expected_file["path"]
-        assert path.exists(), f"Expected file {path} does not exist."
+    expected_file = {
+        "path": temp_output_dir / round_short_name / "form_runner" / f"{form_publish_name}.json",
+        "expected_output": {
+            "startPage": "/organisation-name",
+            "pages": [
+                {
+                    "path": "/organisation-name",
+                    "title": "Organisation Name",
+                    "components": [
+                        {
+                            "name": "organisation_name",
+                            "options": {"hideTitle": False, "classes": ""},
+                            "type": "TextField",
+                            "title": "What is your organisation's name?",
+                            "hint": "This must match the registered legal organisation name",
+                            "schema": {},
+                        }
+                    ],
+                    "next": [{"path": "/organisation-alternative-names"}],
+                },
+                {
+                    "path": "/organisation-alternative-names",
+                    "title": "Alternative names of your organisation",
+                    "components": [
+                        {
+                            "name": "alt_name_1",
+                            "options": {},
+                            "type": "TextField",
+                            "title": "Alternative name 1",
+                            "schema": {},
+                        }
+                    ],
+                    "next": [{"path": "/organisation-address"}],
+                },
+                {
+                    "path": "/organisation-address",
+                    "title": "Organisation Address",
+                    "components": [
+                        {
+                            "name": "organisation_address",
+                            "options": {},
+                            "type": "UkAddressField",
+                            "title": "What is your organisation's address?",
+                            "schema": {},
+                        }
+                    ],
+                    "next": [{"path": "/organisation-classification"}],
+                },
+                {
+                    "path": "/organisation-classification",
+                    "title": "Organisation Classification",
+                    "components": [
+                        {
+                            "name": "organisation_classification",
+                            "options": {"hideTitle": False, "classes": ""},
+                            "type": "RadiosField",
+                            "title": "How is your organisation classified?",
+                            "list": "classifications_list",
+                            "schema": {},
+                        }
+                    ],
+                    "next": [{"path": "/summary"}],
+                },
+                {
+                    "path": "/summary",
+                    "title": "Check your answers",
+                    "components": [],
+                    "next": [],
+                    "controller": "./pages/summary.js",
+                },
+            ],
+            "lists": [
+                {
+                    "name": "classifications_list",
+                    "type": "string",
+                    "items": [
+                        {"text": "Charity", "value": "charity"},
+                        {"text": "Public Limited Company", "value": "plc"},
+                    ],
+                }
+            ],
+            "conditions": [],
+            "sections": [],
+            "outputs": [],
+            "skipSummary": False,
+            "name": "About your organisation",
+        },
+    }
+    path = expected_file["path"]
+    assert path.exists(), f"Expected file {path} does not exist."
 
     with open(expected_file["path"], "r") as file:
         data = json.load(file)

--- a/tests/unit/app/import_config/test_load_form_json.py
+++ b/tests/unit/app/import_config/test_load_form_json.py
@@ -34,8 +34,11 @@ def test_generate_config_for_round_valid_input(seed_dynamic_data, _db, filename,
     file_path = Path("tests") / "test_data" / filename
     with open(file_path, "r") as json_file:
         form = json.load(json_file)
-        form["filename"] = filename
-        form_configs.append(form)
+        form_config = {
+            "filename": filename,
+            "form_json": form,
+        }
+        form_configs.append(form_config)
     load_form_jsons(form_configs)
 
     expected_form_count = 1


### PR DESCRIPTION
### 🎫 Ticket

[Start using whole form JSON for forms export](https://mhclgdigital.atlassian.net/browse/FLS-1466)

### 🌍 Background

As part of the export process in FAB, whereby we generate a ZIP file full of Pre-Award and Form Runner config, we re-build all of the funding round’s form JSONs at runtime from the sets of relational entities we decomposed JSON files down into at import (see `generate_form_jsons_for_round` in `app.export_config.generate_fund_round_form_jsons`). Put another way, we call the `build_form_json` function.

We are moving away from relational form entities in FAB. Now we are storing whole form JSON directly, we can simply replace the `build_form_json` call with direct access to the `Form` model’s `form_json` attribute.

### 🚧 Testing

- All relevant tests have been updated
- To test yourself...
   - Run FAB locally (run `make pre up` in the https://github.com/communitiesuk/funding-service-design-docker-runner repo)
   - Upload a form created in the Form Designer at https://fund-application-builder.communities.gov.localhost:3011/templates/create (you can find such a form in the `fsd_config` directory of the https://github.com/communitiesuk/digital-form-builder-adapter repo)
   - Create an application (you'll need to create a grant first)
   - Click "Build application" on the new application, add a section to the application, click "Edit section" and add the form that you uploaded to the section
   - Click "Download application ZIP file"
   - Confirm that the JSON in the `form_runner` directory of the ZIP file is _identical_ to the JSON file that you uploaded