### PR TITLE
FLS:1465 use whole json in questions endpoints

### DIFF
--- a/app/blueprints/application/routes.py
+++ b/app/blueprints/application/routes.py
@@ -146,7 +146,7 @@ def view_all_questions(round_id):
     sections_in_round = round.sections
     section_data = []
     for section in sections_in_round:
-        forms = [{"name": form.runner_publish_name, "form_data": build_form_json(form)} for form in section.forms]
+        forms = [{"name": form.runner_publish_name, "form_data": form.form_json} for form in section.forms]
         section_data.append({"section_title": section.name_in_apply_json["en"], "forms": forms})
 
     print_data = generate_print_data_for_sections(

--- a/app/blueprints/template/routes.py
+++ b/app/blueprints/template/routes.py
@@ -16,7 +16,6 @@ from app.db.queries.application import (
     update_form,
 )
 from app.export_config.generate_all_questions import generate_html
-from app.export_config.generate_form import build_form_json
 from app.shared.forms import DeleteConfirmationForm
 from app.shared.helpers import flash_message, human_to_kebab_case
 from app.shared.json_validation import validate_form_json
@@ -90,7 +89,7 @@ def template_questions(form_id):
     section_data = [
         {
             "section_title": f"Preview of form [{form.name_in_apply_json['en']}]",
-            "forms": [{"name": form.runner_publish_name, "form_data": build_form_json(form)}],
+            "forms": [{"name": form.runner_publish_name, "form_data": form.form_json}],
         }
     ]
     print_data = generate_print_data_for_sections(

--- a/tests/seed_test_data.py
+++ b/tests/seed_test_data.py
@@ -424,6 +424,16 @@ def init_unit_test_data() -> dict:
         section_index=1,
         runner_publish_name="about-your-org",
         template_name="About your organization template",
+        form_json={
+            "name": "Minimal Form",
+            "startPage": "/start",
+            "sections": [],
+            "pages": [{"path": "/start", "title": "Start Page", "components": [], "next": []}],
+            "lists": [],
+            "conditions": [],
+            "outputs": [],
+            "skipSummary": False,
+        },
     )
     p1: Page = Page(
         page_id=uuid4(),

--- a/tests/unit/app/blueprints/template/test_routes.py
+++ b/tests/unit/app/blueprints/template/test_routes.py
@@ -289,6 +289,7 @@ def test_template_questions_view(flask_test_client, seed_dynamic_data):
     # Title component availability check
     assert "About your organization template" in html, "Template title is missing"
     assert "This template contains the following questions." in html, "Title description is missing"
+    assert "Start Page" in html, "Page title is missing"
 
 
 @pytest.mark.usefixtures("set_auth_cookie", "patch_validate_token_rs256_allowed_domain_user")


### PR DESCRIPTION
Ticket: https://mhclgdigital.atlassian.net/browse/FLS-1465


### Change description
- Use whole json instead of rebuilding the form in /all-questions and /questions endpoints
- Test was failing because generate_metadata() in metadat_utils.py (app/all_questions) expects a populated form json
- Added minimal form json structure for form json and validated the page title from form json in test

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
- User should be able to see the all questions pages successfully


### Screenshots of UI changes (if applicable)
