### PR TITLE
FLS-1476 - Use whole form JSON for assessment config export

### DIFF
--- a/app/export_config/generate_assessment_config.py
+++ b/app/export_config/generate_assessment_config.py
@@ -1,196 +1,19 @@
 import copy
 import json
-import os
-
-import click
 
 from app.all_questions.metadata_utils import form_json_to_assessment_display_types
 from app.db import db
-from app.db.models import Component, Criteria, Section, Subcriteria, Theme
-from app.db.models.application_config import READ_ONLY_COMPONENTS
-from app.db.queries.application import get_form_for_component
+from app.db.models import Form, Section
+from app.db.models.application_config import READ_ONLY_COMPONENTS, ComponentType
 from app.export_config import helpers
-from app.shared.helpers import human_to_kebab_case
+from app.shared.helpers import find_enum, human_to_kebab_case
 
 
-def generate_field_info_from_forms(forms_dir: str) -> dict:
-    """Generates the display info for all fields in a form
-
-    Args:
-        forms_dir (str): Directory containing the forms
-
-    Returns:
-        dict: Dictionary of field IDs to display info
-    """
-    results = {}
-    for file_name in os.listdir(forms_dir):
-        with open(os.path.join(forms_dir, file_name), "r") as f:
-            form_data = json.load(f)
-            results.update(build_answers_from_form(form_data, file_name.split(".")[0]))
-
-    return results
-
-
-def build_answers_from_form(form_data: dict, form_name: str) -> dict:
-    """Generates the list of display info for a particular form
-
-    Args:
-        form_data (dict): Full form data
-        form_name (str): name of this form
-
-    Returns:
-        dict: Dictionary of field IDs to display info
-    """
-    results = {}
-    for page in form_data["pages"]:
-        for component in page["components"]:
-            question = component.get("title", None)
-            if component["type"].lower() == "multiinputfield":
-                question = [page["title"]]
-                child_fields = {}
-                for field in component["children"]:
-                    child_fields[field["name"]] = {
-                        "column_title": field["title"],
-                        "type": field["type"],
-                    }
-                question.append(child_fields)
-
-            results[component["name"]] = {
-                "field_id": component["name"],
-                "form_name": form_name,
-                "field_type": component["type"],
-                # TODO fix this "presentation_type":
-                # form_json_to_assessment_display_types.get(component["type"].lower(), None),
-                "question": question,
-            }
-
-    return results
-
-
-def build_answer(component: Component) -> dict:
-    form = get_form_for_component(component)
-    return {
-        "field_id": component.component_id,
-        "form_name": form.runner_publish_name,
-        "field_type": component.type,
-        "presentation_type": component.assessment_display_type,
-        "question": component.title,
-    }
-
-
-def build_theme(theme: Theme) -> dict:
-    """Creates a theme object and populates with the display info for the answers in that theme
-
-    Args:
-        theme_id (str): ID of the theme
-        field_info (dict): Dictionary of field display info for all fields
-
-    Returns:
-        dict: Dictionary representing a theme within the assessment config
-    """
-    built_theme = {"id": theme.theme_id, "name": theme.name, "answers": []}
-    for component in theme.components:
-        built_theme["answers"].append(build_answer(component))
-
-    return built_theme
-
-
-def build_subcriteria(sc: Subcriteria) -> dict:
-    """Generates a sub criteria, containing themes
-
-    Args:
-        sub_criteria (dict): Input subcriteria details
-        field_info (dict): Dictionary of fields and their display info
-
-    Returns:
-        dict: Dictionary of subcriteria IDs to their config (containing themes)
-    """
-    built_sc = {"id": sc.subcriteria_id, "name": sc.name, "themes": []}
-    for theme in sc.themes:
-        built_sc["themes"].append(build_theme(theme))
-    return built_sc
-
-
-def build_assessment_config(criteria_list: list[Criteria]) -> dict:
-    """Builds a dictionary represting the full assessment config based on the input data
-
-    Args:
-        input_data (dict): Dictionary of input data (eg. test_data/in/ns_unscored.json)
-        field_info (dict): Dictionary of field IDs to their display info
-
-    Returns:
-        dict: Full assessment display config
-    """
-    results = {}
-    unscored_sections = []
-    scored_sections = []
-    for criteria in criteria_list:
-        built_criteria = {
-            "id": criteria.criteria_id,
-            "name": criteria.name,
-            "subcriteria": [],
-            "weighting": criteria.weighting,
-        }
-        for sc in criteria.subcriteria:
-            built_criteria["subcriteria"].append(build_subcriteria(sc=sc))
-
-        if criteria.weighting > 0:
-            scored_sections.append(built_criteria)
-        else:
-            unscored_sections.append(built_criteria)
-
-    results["unscored_sections"] = unscored_sections
-    results["scored_sections"] = scored_sections
-    return results
-
-
-@click.command()
-@click.option(
-    "--input_folder",
-    default="./config_reuse/test_data/in/",
-    help="Input configuration",
-    prompt=True,
-)
-@click.option(
-    "--input_file",
-    default="assmnt_unscored.json",
-    help="Input configuration",
-    prompt=True,
-)
-@click.option(
-    "--output_folder",
-    default="./config_reuse/test_data/out",
-    help="Output destination",
-    prompt=True,
-)
-@click.option(
-    "--output_file",
-    default="assessment_mapping_unscored.json",
-    help="Output destination",
-    prompt=True,
-)
-@click.option(
-    "--forms_dir",
-    default="./config_reuse/test_data/out/forms/",
-    help="Directory containing forms",
-    prompt=True,
-)
-def generate_assessment_config(
-    input_folder,
-    input_file,
-    output_folder,
-    output_file,
-    forms_dir,
-):
-    with open(os.path.join(input_folder, input_file), "r") as f:
-        input_data = json.load(f)
-
-    field_info = generate_field_info_from_forms(forms_dir)
-
-    assessment_config = build_assessment_config(input_data, field_info)
-
-    with open(os.path.join(output_folder, output_file), "w") as f:
-        json.dump(assessment_config, f)
+def _get_component_type(component: dict) -> ComponentType:
+    component_type = component.get("type")
+    if component_type is None or (established_component_type := find_enum(ComponentType, component_type)) is None:
+        raise ValueError(f"Component type not found: {component_type}")
+    return established_component_type
 
 
 def generate_assessment_config_for_round(fund_config, round_config, base_output_dir):
@@ -208,7 +31,9 @@ def generate_assessment_config_for_round(fund_config, round_config, base_output_
     fund_round_ids = f"{fund_id}:{round_id}"
 
     unscored = []
-    sections = db.session.query(Section).filter(Section.round_id == round_id).order_by(Section.index).all()
+    sections: list[Section] = (
+        db.session.query(Section).filter(Section.round_id == round_id).order_by(Section.index).all()
+    )
     for _i, section in enumerate(sections, start=1):
         criteria = {
             "id": human_to_kebab_case(section.name_in_apply_json["en"]),
@@ -218,28 +43,32 @@ def generate_assessment_config_for_round(fund_config, round_config, base_output_
         unscored.append(criteria)
 
         for form in section.forms:
+            form: Form
             sc = {
                 "id": form.runner_publish_name,
                 "name": form.name_in_apply_json["en"],
                 "themes": [],
             }
-            for page in form.pages:
-                if page.display_path == "summary":
+            for page in form.form_json.get("pages"):
+                page: dict
+                if page.get("path").lstrip("/") == "summary":
                     continue
                 theme = {
-                    "id": human_to_kebab_case(page.name_in_apply_json["en"]),
-                    "name": page.name_in_apply_json["en"],
+                    "id": human_to_kebab_case(page.get("title")),
+                    "name": page.get("title"),
                     "answers": [],
                 }
-                for component in page.components:
-                    if component.type in READ_ONLY_COMPONENTS:
+                for component in page.get("components"):
+                    component: dict
+                    component_type = _get_component_type(component)
+                    if component_type in READ_ONLY_COMPONENTS:
                         continue
                     answer = {
-                        "field_id": component.runner_component_name,
+                        "field_id": component.get("name"),
                         "form_name": form.runner_publish_name,
-                        "field_type": component.type.value[0].lower() + component.type.value[1:],
-                        "presentation_type": form_json_to_assessment_display_types.get(component.type.name, "text"),
-                        "question": component.title,
+                        "field_type": component_type.value[0].lower() + component_type.value[1:],
+                        "presentation_type": form_json_to_assessment_display_types.get(component_type.name, "text"),
+                        "question": component.get("title"),
                     }
                     theme["answers"].append(answer)
                 sc["themes"].append(theme)
@@ -254,7 +83,3 @@ def generate_assessment_config_for_round(fund_config, round_config, base_output_
         unscored=json.dumps(unscored),
     )
     helpers.write_config(assess_output, "assessment_config", round_short_name, "assessment", base_output_dir)
-
-
-if __name__ == "__main__":
-    generate_assessment_config()

--- a/tests/unit/app/export_config/test_generate_assessment_config.py
+++ b/tests/unit/app/export_config/test_generate_assessment_config.py
@@ -1,45 +1,214 @@
-from app.db.models import Fund
-from app.export_config.generate_assessment_config import build_assessment_config
-from tests.helpers import get_fund_by_id
-from tests.unit_test_data import mock_criteria_1, mock_criteria_1_id, mock_form_1
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+
+from app.db.models.application_config import ComponentType
+from app.export_config.generate_assessment_config import _get_component_type, generate_assessment_config_for_round
 
 
-def test_build_basic_structure(mocker):
-    mocker.patch("app.export_config.generate_assessment_config.get_form_for_component", return_value=mock_form_1)
+class TestGetComponentType:
+    def test_valid_component_type(self):
+        component = {"type": "TextField"}
+        result = _get_component_type(component)
+        assert result == ComponentType.TEXT_FIELD
 
-    results = build_assessment_config([mock_criteria_1])
-    assert "unscored_sections" in results
-    unscored = next(section for section in results["unscored_sections"] if section["id"] == mock_criteria_1_id)
-    assert unscored["name"] == "Unscored"
+    def test_missing_component_type(self):
+        component = {}
+        with pytest.raises(ValueError, match="Component type not found: None"):
+            _get_component_type(component)
 
-
-def test_with_field_info(mocker):
-    mocker.patch("app.export_config.generate_assessment_config.get_form_for_component", return_value=mock_form_1)
-    results = build_assessment_config([mock_criteria_1])
-    assert len(results["unscored_sections"]) == 1
-    unscored_subcriteria = next(
-        section for section in results["unscored_sections"] if section["id"] == mock_criteria_1_id
-    )["subcriteria"]
-    assert unscored_subcriteria
-    assert unscored_subcriteria[0]["name"] == "Organisation Information"
-
-    unscored_themes = unscored_subcriteria[0]["themes"]
-    assert len(unscored_themes) == 1
-
-    general_info = unscored_themes[0]
-    assert general_info["name"] == "General Information"
-    assert len(general_info["answers"]) == 2
+    def test_invalid_component_type(self):
+        component = {"type": "InvalidType"}
+        with pytest.raises(ValueError, match="Component type not found: InvalidType"):
+            _get_component_type(component)
 
 
-# TODO this fails with components from a template (branching logic)
-def test_build_assessment_config_no_branching(seed_dynamic_data):
-    f: Fund = get_fund_by_id(seed_dynamic_data["funds"][0].fund_id)
-    criteria = f.rounds[0].criteria[0]
-    result = build_assessment_config(criteria_list=[criteria])
-    assert result
-    first_unscored = result["unscored_sections"][0]
-    assert first_unscored
-    assert first_unscored["name"] == "Unscored"
-    assert len(first_unscored["subcriteria"]) == 1
-    assert len(first_unscored["subcriteria"][0]["themes"]) == 1
-    assert len(first_unscored["subcriteria"][0]["themes"][0]["answers"]) == 2
+class TestGenerateAssessmentConfig:
+    @pytest.fixture
+    def configs(self):
+        fund_config = {"id": "fund-123", "short_name": "test_fund"}
+        round_config = {"id": "round-456", "short_name": "round_1"}
+        return fund_config, round_config
+
+    @pytest.fixture
+    def mock_form_data(self):
+        mock_form = Mock()
+        mock_form.runner_publish_name = "test-form"
+        mock_form.name_in_apply_json = {"en": "Test Form"}
+        mock_form.form_json = {
+            "pages": [
+                {
+                    "path": "/contact",
+                    "title": "Contact Details",
+                    "components": [
+                        {"name": "name_field", "type": "TextField", "title": "Your Name"},
+                        {"name": "email_field", "type": "EmailAddressField", "title": "Email"},
+                        {"name": "html_content", "type": "Html", "title": "Info Text"},  # Should be filtered
+                    ],
+                },
+                {
+                    "path": "/summary",  # Should be skipped
+                    "title": "Summary",
+                    "components": [{"name": "summary_field", "type": "TextField", "title": "Summary"}],
+                },
+            ]
+        }
+
+        mock_section = Mock()
+        mock_section.name_in_apply_json = {"en": "Application Details"}
+        mock_section.forms = [mock_form]
+
+        return [mock_section]
+
+    @patch("app.export_config.generate_assessment_config.copy.deepcopy")
+    @patch("app.export_config.generate_assessment_config.db")
+    @patch("app.export_config.generate_assessment_config.helpers")
+    @patch("app.export_config.generate_assessment_config.form_json_to_assessment_display_types")
+    @patch("app.export_config.generate_assessment_config.human_to_kebab_case")
+    def test_basic_config_generation(
+        self, mock_kebab, mock_display_types, mock_helpers, mock_db, mock_deepcopy, configs, mock_form_data
+    ):
+        fund_config, round_config = configs
+        mock_kebab.side_effect = lambda x: x.lower().replace(" ", "-")
+        mock_display_types.get.return_value = "text"
+
+        # Setup database query
+        mock_db.session.query.return_value.filter.return_value.order_by.return_value.all.return_value = mock_form_data
+
+        # Setup template - this is the key fix
+        mock_template = Mock()
+        mock_template.substitute.return_value = "generated_config"
+        mock_deepcopy.return_value = mock_template
+
+        # Run function
+        generate_assessment_config_for_round(fund_config, round_config, "/output")
+
+        # Verify template was called with correct parameters
+        mock_template.substitute.assert_called_once()
+        call_args = mock_template.substitute.call_args[1]
+        assert call_args["fund_round"] == "TEST_FUNDROUND_1"
+        assert call_args["fund_id"] == "fund-123"
+        assert call_args["round_id"] == "round-456"
+
+        # Verify config was written
+        mock_helpers.write_config.assert_called_once()
+
+    @patch("app.export_config.generate_assessment_config.copy.deepcopy")
+    @patch("app.export_config.generate_assessment_config.db")
+    @patch("app.export_config.generate_assessment_config.helpers")
+    @patch("app.export_config.generate_assessment_config.form_json_to_assessment_display_types")
+    @patch("app.export_config.generate_assessment_config.human_to_kebab_case")
+    def test_unscored_data_structure(
+        self, mock_kebab, mock_display_types, mock_helpers, mock_db, mock_deepcopy, configs, mock_form_data
+    ):
+        fund_config, round_config = configs
+        mock_kebab.side_effect = lambda x: x.lower().replace(" ", "-")
+        mock_display_types.get.return_value = "text"
+
+        mock_db.session.query.return_value.filter.return_value.order_by.return_value.all.return_value = mock_form_data
+
+        mock_template = Mock()
+        mock_template.substitute.return_value = "config"
+        mock_deepcopy.return_value = mock_template
+
+        generate_assessment_config_for_round(fund_config, round_config, "/output")
+
+        # Check the unscored data structure
+        call_args = mock_template.substitute.call_args[1]
+        unscored = json.loads(call_args["unscored"])
+
+        # Should have one criteria (section)
+        assert len(unscored) == 1
+        criteria = unscored[0]
+        assert criteria["name"] == "Application Details"
+
+        # Should have one sub_criteria (form)
+        assert len(criteria["sub_criteria"]) == 1
+        sub_criteria = criteria["sub_criteria"][0]
+        assert sub_criteria["name"] == "Test Form"
+
+        # Should have one theme (page, summary skipped)
+        assert len(sub_criteria["themes"]) == 1
+        theme = sub_criteria["themes"][0]
+        assert theme["name"] == "Contact Details"
+
+        # Should have 2 answers (HTML component filtered out)
+        assert len(theme["answers"]) == 2
+
+        # Check answer structure
+        answer = theme["answers"][0]
+        assert answer["field_id"] == "name_field"
+        assert answer["form_name"] == "test-form"
+        assert answer["field_type"] == "textField"  # First letter lowercase
+        assert answer["question"] == "Your Name"
+
+    @patch("app.export_config.generate_assessment_config.copy.deepcopy")
+    @patch("app.export_config.generate_assessment_config.db")
+    @patch("app.export_config.generate_assessment_config.helpers")
+    @patch("app.export_config.generate_assessment_config.form_json_to_assessment_display_types")
+    @patch("app.export_config.generate_assessment_config.human_to_kebab_case")
+    def test_readonly_components_filtered(
+        self, mock_kebab, mock_display_types, mock_helpers, mock_db, mock_deepcopy, configs
+    ):
+        fund_config, round_config = configs
+        mock_kebab.side_effect = lambda x: x.lower().replace(" ", "-")
+        mock_display_types.get.return_value = "text"
+
+        # Create form with only readonly components
+        mock_form = Mock()
+        mock_form.runner_publish_name = "readonly-form"
+        mock_form.name_in_apply_json = {"en": "Readonly Form"}
+        mock_form.form_json = {
+            "pages": [
+                {
+                    "path": "/readonly",
+                    "title": "Readonly Page",
+                    "components": [
+                        {"name": "html_field", "type": "Html", "title": "HTML"},
+                        {"name": "para_field", "type": "Para", "title": "Paragraph"},
+                    ],
+                }
+            ]
+        }
+
+        mock_section = Mock()
+        mock_section.name_in_apply_json = {"en": "Test"}
+        mock_section.forms = [mock_form]
+
+        mock_db.session.query.return_value.filter.return_value.order_by.return_value.all.return_value = [mock_section]
+
+        mock_template = Mock()
+        mock_template.substitute.return_value = "config"
+        mock_deepcopy.return_value = mock_template
+
+        generate_assessment_config_for_round(fund_config, round_config, "/output")
+
+        # Should have no answers since all components are readonly
+        call_args = mock_template.substitute.call_args[1]
+        unscored = json.loads(call_args["unscored"])
+        answers = unscored[0]["sub_criteria"][0]["themes"][0]["answers"]
+        assert len(answers) == 0
+
+    @patch("app.export_config.generate_assessment_config.copy.deepcopy")
+    @patch("app.export_config.generate_assessment_config.db")
+    @patch("app.export_config.generate_assessment_config.helpers")
+    @patch("app.export_config.generate_assessment_config.form_json_to_assessment_display_types")
+    @patch("app.export_config.generate_assessment_config.human_to_kebab_case")
+    def test_empty_sections(self, mock_kebab, mock_display_types, mock_helpers, mock_db, mock_deepcopy, configs):
+        fund_config, round_config = configs
+        mock_kebab.side_effect = lambda x: x.lower().replace(" ", "-")
+
+        # No sections
+        mock_db.session.query.return_value.filter.return_value.order_by.return_value.all.return_value = []
+
+        mock_template = Mock()
+        mock_template.substitute.return_value = "config"
+        mock_deepcopy.return_value = mock_template
+
+        generate_assessment_config_for_round(fund_config, round_config, "/output")
+
+        # Should have empty unscored list
+        call_args = mock_template.substitute.call_args[1]
+        unscored = json.loads(call_args["unscored"])
+        assert unscored == []


### PR DESCRIPTION
### 🎫 Ticket

[Start using whole form JSON for assessment config export](https://mhclgdigital.atlassian.net/browse/FLS-1476)

### 🌍 Background

As part of the export process in FAB, whereby we generate a ZIP file full of Pre-Award and Form Runner config, we generate a minimal assessment config, grouping questions into assessment criteria, subcriteria and themes using a naive mapping from the application config (section → criteria, form → subcriteria, page → theme). This process is tightly coupled to FAB’s relational forms storage model, leveraging ORM-powered syntax.

We are moving away from relational form entities in FAB. Now we are storing whole form JSON directly. We therefore need to rewrite the assessment config generation logic so that it works with whole JSON blobs, in order to avoid a functional regression.

### ♻️ Changes

This change simply replaces any code that relies on soon-to-be-deprecated SQLAlchemy models like Page with code that can simply reference the whole form JSON stored in the form_json column of the form table. In some cases this means leveraging code from load_form_json, which is where we create models from the form JSON, e.g., I can see in load_form_json that Component.runner_component_name is just component.get('name'), therefore we can swap out out component.runner_compnent_name for component.get('name') in our updated assessment config generation.

This change also removes the redundant generate_assessment_config function and the functions only it calls, because this is a completely separate flow to the thing we actually use (generate_assessment_config_for_round) in the application.

### 🚧 Testing

- Unit tests were previously completely missing for the function actually used by the application - `generate_assessment_config_for_round`
- We previously only tested the function `generate_assessment_config` and the functions it called - but this function was unused by the application, a completely separate piece of logic to `generate_assessment_config_for_round`, and we've removed it now
- Therefore this PR contains a completely rewritten test module that actually tests the thing that needs to be tested