### PR TITLE
FLS-1465 - Start using whole form JSON for 'View form questions' endpoint

### DIFF
--- a/app/blueprints/application/routes.py
+++ b/app/blueprints/application/routes.py
@@ -35,7 +35,7 @@ from app.export_config.generate_all_questions import generate_html
 from app.export_config.generate_assessment_config import (
     generate_assessment_config_for_round,
 )
-from app.export_config.generate_form import _find_page_by_controller, build_form_json
+from app.export_config.generate_form import _find_page_by_controller
 from app.export_config.generate_fund_round_config import generate_config_for_round
 from app.export_config.generate_fund_round_form_jsons import (
     generate_form_jsons_for_round,
@@ -295,7 +295,7 @@ def view_form_questions(round_id, section_id, form_id):
     section_data = [
         {
             "section_title": f"Preview of form [{form.name_in_apply_json['en']}]",
-            "forms": [{"name": form.runner_publish_name, "form_data": build_form_json(form)}],
+            "forms": [{"name": form.runner_publish_name, "form_data": form.form_json}],
         }
     ]
 


### PR DESCRIPTION
### 🎫 Ticket

[Start using whole form JSON for all questions HTML endpoints](https://mhclgdigital.atlassian.net/browse/FLS-1465)

### 📓 Notes

We forgot to swap out the `build_form_json` call in the `view_form_questions` endpoint in the [original PR that covered this ticket](https://github.com/communitiesuk/funding-service-design-fund-application-builder/pull/440).