### PR TITLE
FLS-1470 - Remove unused ORM helper function

### DIFF
--- a/app/shared/helpers.py
+++ b/app/shared/helpers.py
@@ -2,8 +2,6 @@ from dataclasses import asdict, is_dataclass
 
 from flask import flash, render_template
 
-from app.db.models import Page
-
 
 def convert_to_dict(obj):
     if is_dataclass(obj):
@@ -19,24 +17,6 @@ def find_enum(enum_class, value):
         if enum.value == value:
             return enum
     return None
-
-
-def get_all_pages_in_parent_form(db, page_id):
-    # Get the form_id from page_id
-    page = db.session.query(Page).filter(Page.page_id == page_id).first()
-
-    if page is None:
-        raise ValueError(f"No page found with page_id: {page_id}")
-
-    form_id = page.form_id
-
-    # Get all page ids belonging to the form
-    page_ids = db.session.query(Page.page_id).filter(Page.form_id == form_id).all()
-
-    # Extract page_ids from the result
-    page_ids = [p.page_id for p in page_ids]
-
-    return page_ids
 
 
 def flash_message(


### PR DESCRIPTION
🎫 Ticket
[Clean up application code](https://mhclgdigital.atlassian.net/browse/FLS-1470)

### Change description
The get_all_pages_in_parent_form function in app/shared/helpers.py is no longer needed after the transition to using form_json. This function was querying the old Page ORM model directly, but with form_json, pages are accessed directly from the JSON structure instead.

#### Changes:

  - Remove get_all_pages_in_parent_form function
  - Remove unused from app.db.models import Page import

The function is not used anywhere in the codebase and has no associated tests, making it safe to remove as part of the  cleanup.