### PR TITLE
styling visited links

### DIFF
--- a/app/blueprints/application/templates/build_application.html
+++ b/app/blueprints/application/templates/build_application.html
@@ -60,7 +60,7 @@
                         <li class="app-task-list__item task-list__new-design">
                             <span class="app-task-list__task-name">
                                 <h3 class="govuk-body">
-                                    <a class="govuk-link govuk-link--no-visited-state"
+                                    <a class="govuk-link"
                                         target="_blank"
                                         href='{{ url_for("index_bp.preview_form", form_id=form.form_id) }}'>
                                         {{ form.name_in_apply_json["en"] }} (previews in a new tab)
@@ -68,7 +68,7 @@
                                 </h3>
                             </span>
                             <span class="app-task-list__task-actions">
-                                <a class="govuk-link--no-visited-state govuk-!-font-size-19" href="{{ url_for('application_bp.view_form_questions', round_id=round.round_id, section_id=section.section_id, form_id=form.form_id) }}">View questions<span class="govuk-visually-hidden"> for {{ form.name_in_apply_json["en"] }} form</span></a>
+                                <a class="govuk-link govuk-!-font-size-19" href="{{ url_for('application_bp.view_form_questions', round_id=round.round_id, section_id=section.section_id, form_id=form.form_id) }}">View questions<span class="govuk-visually-hidden"> for {{ form.name_in_apply_json["en"] }} form</span></a>
                             </span>
                         </li>
                     {% endfor %}

--- a/app/blueprints/fund/templates/fund_details.html
+++ b/app/blueprints/fund/templates/fund_details.html
@@ -22,7 +22,7 @@
                                 {
                                     "href": url_for(endpoint="fund_bp.edit_fund", fund_id=fund.fund_id, _anchor=form.name_en.id),
                                     "text": "Change",
-                                    "classes": "govuk-link--no-visited-state",
+                                    "classes": "",
                                     "visuallyHiddenText": "Grant name",
                                 }
                             ]
@@ -36,7 +36,7 @@
                                 {
                                     "href": url_for(endpoint="fund_bp.edit_fund", fund_id=fund.fund_id, actions=grant_details,  _anchor=form.name_cy.id),
                                     "text": "Change",
-                                    "classes": "govuk-link--no-visited-state",
+                                    "classes": "",
                                     "visuallyHiddenText": "Welsh grant name",
                                 }
                             ]
@@ -50,7 +50,7 @@
                                 {
                                     "href": url_for(endpoint="fund_bp.edit_fund", fund_id=fund.fund_id, action=grant_details, _anchor=form.short_name.id),
                                     "text": "Change",
-                                    "classes": "govuk-link--no-visited-state",
+                                    "classes": "",
                                     "visuallyHiddenText": "Grant short name",
                                 }
                             ]
@@ -64,7 +64,7 @@
                                 {
                                     "href": url_for(endpoint="fund_bp.edit_fund", fund_id=fund.fund_id, action=grant_details,  _anchor=form.title_en.id),
                                     "text": "Change",
-                                    "classes": "govuk-link--no-visited-state",
+                                    "classes": "",
                                     "visuallyHiddenText": "Application name",
                                 }
                             ]
@@ -78,7 +78,7 @@
                                 {
                                     "href": url_for(endpoint="fund_bp.edit_fund", fund_id=fund.fund_id,  action=grant_details, _anchor=form.title_cy.id),
                                     "text": "Change",
-                                    "classes": "govuk-link--no-visited-state",
+                                    "classes": "",
                                     "visuallyHiddenText": "Welsh application name",
                                 }
                             ]
@@ -92,7 +92,7 @@
                                 {
                                     "href": url_for(endpoint="fund_bp.edit_fund", fund_id=fund.fund_id,  action=grant_details, _anchor=form.funding_type.id),
                                     "text": "Change",
-                                    "classes": "govuk-link--no-visited-state",
+                                    "classes": "",
                                     "visuallyHiddenText": "Funding type",
                                 }
                             ]
@@ -106,7 +106,7 @@
                                 {
                                     "href": url_for(endpoint="fund_bp.edit_fund", fund_id=fund.fund_id, action=grant_details,  _anchor=form.welsh_available.id),
                                     "text": "Change",
-                                    "classes": "govuk-link--no-visited-state",
+                                    "classes": "",
                                     "visuallyHiddenText": "If this grant is available in Welsh",
                                 }
                             ]
@@ -120,7 +120,7 @@
                                 {
                                     "href": url_for(endpoint="fund_bp.edit_fund", fund_id=fund.fund_id, action=grant_details, _anchor=form.description_en.id),
                                     "text": "Change",
-                                    "classes": "govuk-link--no-visited-state",
+                                    "classes": "",
                                     "visuallyHiddenText": "Grant description",
                                 }
                             ]
@@ -134,7 +134,7 @@
                                 {
                                     "href": url_for(endpoint="fund_bp.edit_fund", fund_id=fund.fund_id, action=grant_details, _anchor=form.description_cy.id),
                                     "text": "Change",
-                                    "classes": "govuk-link--no-visited-state",
+                                    "classes": "",
                                     "visuallyHiddenText": "Welsh grant description",
                                 }
                             ]
@@ -148,7 +148,7 @@
                                 {
                                     "href": url_for(endpoint="fund_bp.edit_fund", fund_id=fund.fund_id, action=grant_details, _anchor=form.ggis_scheme_reference_number.id),
                                     "text": "Change",
-                                    "classes": "govuk-link--no-visited-state",
+                                    "classes": "",
                                     "visuallyHiddenText": "GGIS scheme reference number",
                                 }
                             ]

--- a/app/blueprints/fund/templates/view_all_funds.html
+++ b/app/blueprints/fund/templates/view_all_funds.html
@@ -33,7 +33,7 @@
     {% set table_rows = namespace(items=[]) %}
     {% for fund in pagination.items %}
     {% set fund_detail_link %}
-    <a class='govuk-link govuk-link--no-visited-state'
+    <a class='govuk-link'
        href={{ url_for("fund_bp.view_fund_details", fund_id=fund.fund_id) }}>{{ fund.name_json["en"] }}</a>
     {% endset %}
     {% set table_rows.items = table_rows.items + [

--- a/app/blueprints/round/templates/round_details.html
+++ b/app/blueprints/round/templates/round_details.html
@@ -12,7 +12,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
         <h2 class="govuk-heading-l govuk-!-margin-bottom-0">Apply for {{ round.fund.title_json["en"] }}</h2>
-        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('fund_bp.edit_fund', fund_id=round.fund.fund_id,  actions="view_application", round_id=round.round_id, _anchor=fund_form.title_en.id) }}">Change application name</a>
+        <a class="" href="{{ url_for('fund_bp.edit_fund', fund_id=round.fund.fund_id,  actions="view_application", round_id=round.round_id, _anchor=fund_form.title_en.id) }}">Change application name</a>
     </div>
     <div class="govuk-grid-column-one-quarter govuk-!-text-align-right">
         {{ govukButton({ "text": "Build application",
@@ -50,7 +50,7 @@
                             {
                                 "href": url_for(endpoint="round_bp.edit_round", round_id=round.round_id, _anchor=form.title_en.id),
                                 "text": "Change",
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "visuallyHiddenText": "Application round",
                             }
                         ]
@@ -64,7 +64,7 @@
                             {
                                 "href": url_for(endpoint="round_bp.edit_round", round_id=round.round_id, _anchor=form.title_cy.id),
                                 "text": "Change",
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "visuallyHiddenText": "Welsh applicaiton round",
                             }
                         ]
@@ -78,7 +78,7 @@
                             {
                                 "href": url_for(endpoint="round_bp.edit_round", round_id=round.round_id, _anchor=form.short_name.id),
                                 "text": "Change",
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "visuallyHiddenText": "Round short name",
                             }
                         ]
@@ -92,7 +92,7 @@
                             {
                                 "href": url_for(endpoint="round_bp.edit_round", round_id=round.round_id, _anchor=form.opens.id),
                                 "text": "Change",
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "visuallyHiddenText": "Application round opens",
                             }
                         ]
@@ -106,7 +106,7 @@
                             {
                                 "href": url_for(endpoint="round_bp.edit_round", round_id=round.round_id, _anchor=form.deadline.id),
                                 "text": "Change",
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "visuallyHiddenText": "Application round closes",
                             }
                         ]
@@ -120,7 +120,7 @@
                             {
                                 "href": url_for(endpoint="round_bp.edit_round", round_id=round.round_id, _anchor=form.reminder_date.id),
                                 "text": "Change",
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "visuallyHiddenText": "Applicant reminder email",
                             }
                         ]
@@ -134,7 +134,7 @@
                             {
                                 "href": url_for(endpoint="round_bp.edit_round", round_id=round.round_id, _anchor=form.assessment_start.id),
                                 "text": "Change",
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "visuallyHiddenText": "Assessment opens",
                             }
                         ]
@@ -148,7 +148,7 @@
                             {
                                 "href": url_for(endpoint="round_bp.edit_round", round_id=round.round_id, _anchor=form.assessment_deadline.id),
                                 "text": "Change",
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "visuallyHiddenText": "Assessment closes",
                             }
                         ]
@@ -162,7 +162,7 @@
                             {
                                 "href": url_for(endpoint="round_bp.edit_round", round_id=round.round_id, _anchor=form.guidance_url.id),
                                 "text": "Change",
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "visuallyHiddenText": "Assessor guidance link",
                             }
                         ]
@@ -176,7 +176,7 @@
                             {
                                 "href": url_for(endpoint="round_bp.edit_round", round_id=round.round_id, _anchor=form.contact_email.id),
                                 "text": "Change",
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "visuallyHiddenText": "Grant team email address",
                             }
                         ]
@@ -190,7 +190,7 @@
                             {
                                 "href": url_for(endpoint="round_bp.edit_round", round_id=round.round_id, _anchor=form.instructions_en.id),
                                 "text": "Change",
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "visuallyHiddenText": "Before you apply guidance",
                             }
                         ]
@@ -204,7 +204,7 @@
                             {
                                 "href": url_for(endpoint="round_bp.edit_round", round_id=round.round_id, _anchor=form.instructions_cy.id),
                                 "text": "Change",
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "visuallyHiddenText": "Welsh before you apply guidance",
                             }
                         ]
@@ -218,7 +218,7 @@
                             {
                                 "href": url_for(endpoint="round_bp.edit_round", round_id=round.round_id, _anchor=form.application_guidance_en.id),
                                 "text": "Change",
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "visuallyHiddenText": "Completing the application guidance",
                             }
                         ]
@@ -232,7 +232,7 @@
                             {
                                 "href": url_for(endpoint="round_bp.edit_round", round_id=round.round_id, _anchor=form.application_guidance_cy.id),
                                 "text": "Change",
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "visuallyHiddenText": "Welsh completing the application guidance",
                             }
                         ]
@@ -246,7 +246,7 @@
                             {
                                 "href": url_for(endpoint="round_bp.edit_round", round_id=round.round_id, _anchor=form.feedback_link.id),
                                 "text": "Change",
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "visuallyHiddenText": "Feedback link",
                             }
                         ]
@@ -260,7 +260,7 @@
                             {
                                 "href": url_for(endpoint="round_bp.edit_round", round_id=round.round_id, _anchor=form.prospectus_link.id),
                                 "text": "Change",
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "visuallyHiddenText": "Prospectus link",
                             }
                         ]
@@ -274,7 +274,7 @@
                             {
                                 "href": url_for(endpoint="round_bp.edit_round", round_id=round.round_id, _anchor=form.privacy_notice_link.id),
                                 "text": "Change",
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "visuallyHiddenText": "Privacy notice link",
                             }
                         ]
@@ -288,7 +288,7 @@
                             {
                                 "href": url_for(endpoint="round_bp.edit_round", round_id=round.round_id, _anchor=form.project_name_field_id.id),
                                 "text": "Change",
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "visuallyHiddenText": "Project name field ID ",
                             }
                         ]
@@ -302,7 +302,7 @@
                             {
                                 "href": url_for(endpoint="round_bp.edit_round", round_id=round.round_id, _anchor=form.eoi_decision_schema_en.id),
                                 "text": "Change",
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "visuallyHiddenText": "Expression of interest decision schema",
                             }
                         ]
@@ -316,7 +316,7 @@
                             {
                                 "href": url_for(endpoint="round_bp.edit_round", round_id=round.round_id, _anchor=form.eoi_decision_schema_cy.id),
                                 "text": "Change",
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "visuallyHiddenText": "Welsh expression of interest decision schema",
                             }
                         ]
@@ -330,7 +330,7 @@
                             {
                                 "href": url_for(endpoint="round_bp.edit_round", round_id=round.round_id, _anchor=form.application_fields_download_available.id),
                                 "text": "Change",
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "visuallyHiddenText": "Allow assessors to download application fields",
                             }
                         ]
@@ -344,7 +344,7 @@
                             {
                                 "href": url_for(endpoint="round_bp.edit_round", round_id=round.round_id, _anchor=form.display_logo_on_pdf_exports.id),
                                 "text": "Change",
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "visuallyHiddenText": "Have the MHCLG logo on PDFs",
                             }
                         ]
@@ -358,7 +358,7 @@
                             {
                                 "href": url_for(endpoint="round_bp.edit_round", round_id=round.round_id, _anchor=form.mark_as_complete_enabled.id),
                                 "text": "Change",
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "visuallyHiddenText": "Applicants to mark sections as complete",
                             }
                         ]
@@ -372,7 +372,7 @@
                             {
                                 "href": url_for(endpoint="round_bp.edit_round", round_id=round.round_id, _anchor=form.is_expression_of_interest.id),
                                 "text": "Change",
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "visuallyHiddenText": "Is this application round an expression of interest",
                             }
                         ]
@@ -386,7 +386,7 @@
                             {
                                 "href": url_for(endpoint="round_bp.edit_round", round_id=round.round_id, _anchor=form.has_feedback_survey.id),
                                 "text": "Change",
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "visuallyHiddenText": "Include a feedback survey",
                             }
                         ]
@@ -400,7 +400,7 @@
                             {
                                 "href": url_for(endpoint="round_bp.edit_round", round_id=round.round_id, _anchor=form.is_feedback_survey_optional.id),
                                 "text": "Change",
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "visuallyHiddenText": "Is the feedback survey optional",
                             }
                         ]
@@ -414,7 +414,7 @@
                             {
                                 "href": url_for(endpoint="round_bp.edit_round", round_id=round.round_id, _anchor=form.has_research_survey.id),
                                 "text": "Change",
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "visuallyHiddenText": "include research survey",
                             }
                         ]
@@ -428,7 +428,7 @@
                             {
                                 "href": url_for(endpoint="round_bp.edit_round", round_id=round.round_id, _anchor=form.is_research_survey_optional.id),
                                 "text": "Change",
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "visuallyHiddenText": "Is the research survey optional",
                             }
                         ]
@@ -442,7 +442,7 @@
                             {
                                 "href": url_for(endpoint="round_bp.edit_round", round_id=round.round_id, _anchor=form.eligibility_config.id),
                                 "text": "Change",
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "visuallyHiddenText": "Do applicants need to pass eligibility questions before applying",
                             }
                         ]

--- a/app/blueprints/round/templates/view_all_rounds.html
+++ b/app/blueprints/round/templates/view_all_rounds.html
@@ -35,7 +35,7 @@
         {% for round in pagination.items %}
 
         {% set round_detail_link %}
-        <a class='govuk-link govuk-link--no-visited-state'
+        <a class='govuk-link'
            href='{{ url_for("round_bp.round_details", round_id=round.round_id) }}'>
             Apply for {{ round.fund.title_json["en"] }}</a>
         {% endset %}
@@ -47,7 +47,7 @@
         {% endset %}
 
         {% set action_link %}
-        <a class='govuk-link govuk-link--no-visited-state'
+        <a class='govuk-link'
         href='{{ url_for("application_bp.build_application", round_id=round.round_id) }}'>
             {% if round.status == 'Complete' %}View application<span class="govuk-visually-hidden"> for {{ round.fund.title_json["en"] }} {{ round.title_json["en"] }}</span>{% else %}Build application<span class="govuk-visually-hidden"> for {{ round.fund.title_json["en"] }} {{ round.title_json["en"] }}</span>{% endif %}
         </a>

--- a/app/blueprints/template/templates/template_details.html
+++ b/app/blueprints/template/templates/template_details.html
@@ -9,7 +9,7 @@
         <div class="govuk-grid-column-full">
             <h1 class="govuk-heading-l">{{ form.template_name }}</h1>
             <p class="govuk-body">
-                <a class='govuk-link govuk-link--no-visited-state'
+                <a class='govuk-link'
                    target="_blank"
                    href='{{ url_for("index_bp.preview_form", form_id=form.form_id) }}'>
                     Preview template (opens in a new tab)
@@ -28,7 +28,7 @@
                         "actions": {
                             "items": [
                                 {
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "href": url_for(endpoint="template_bp.edit_template", form_id=form.form_id, actions='template_details', _anchor=form_obj.template_name.id),
                                 "text": "Change",
                                 "visuallyHiddenText": "Template name",
@@ -42,7 +42,7 @@
                         "actions": {
                             "items": [
                                 {
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "href": url_for(endpoint="template_bp.edit_template", form_id=form.form_id, actions='template_details', _anchor=form_obj.tasklist_name.id),
                                 "text": "Change",
                                 "visuallyHiddenText": "Task name",
@@ -56,7 +56,7 @@
                         "actions": {
                             "items": [
                                 {
-                                "classes": "govuk-link--no-visited-state",
+                                "classes": "",
                                 "href": url_for(endpoint="template_bp.edit_template", form_id=form.form_id, actions='template_details', _anchor=form_obj.file.id),
                                 "text": "Change",
                                 "visuallyHiddenText": "Template JSON file",
@@ -71,7 +71,7 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <p class="govuk-body">
-                <a class='govuk-link govuk-link--no-visited-state'
+                <a class='govuk-link'
                    href='{{ url_for("template_bp.template_questions", form_id=form.form_id) }}'>
                     View template questions
                 </a>

--- a/app/blueprints/template/templates/view_all_templates.html
+++ b/app/blueprints/template/templates/view_all_templates.html
@@ -20,7 +20,7 @@
         <p class="govuk-body">
             View existing templates or upload a new template you have created using
             <br>
-            <a class="govuk-link govuk-link--no-visited-state"
+            <a class='govuk-link'
                target="_blank"
                href="{{ form_designer_url }}">Form Designer (opens in a new tab)</a>.
         </p>
@@ -61,13 +61,13 @@
         {% for form in pagination.items %}
 
         {% set form_link %}
-        <a class='govuk-link govuk-link--no-visited-state'
+        <a class='govuk-link'
            href='{{ url_for('template_bp.template_details', form_id=form.form_id) }}'>{{ form.template_name }}</a>
         {% endset %}
 
         {% set form_preview_link %}
-        <a class='govuk-link govuk-link--no-visited-state'
-        target="_blank"
+        <a class='govuk-link'
+           target="_blank"
         href='{{ url_for("index_bp.preview_form", form_id=form.form_id) }}'>
             Preview <span class="govuk-visually-hidden">{{ form.template_name }} form</span> in a new tab</a>
         {% endset %}

--- a/tests/unit/app/blueprints/fund/test_routes.py
+++ b/tests/unit/app/blueprints/fund/test_routes.py
@@ -330,7 +330,7 @@ def test_view_fund_details(flask_test_client, seed_dynamic_data):
     html = response.data.decode("utf-8")
     assert f'<h1 class="govuk-heading-l">{test_fund.name_json["en"]}</h1>' in html
     assert (
-        f'<a class="govuk-link govuk-link--no-visited-state" href="/grants/{test_fund.fund_id}/edit#name_en">Change'
+        f'<a class="govuk-link" href="/grants/{test_fund.fund_id}/edit#name_en">Change'
         f'<span class="govuk-visually-hidden"> Grant name</span></a>' in html  # noqa: E501
     )
     assert "Back" in html


### PR DESCRIPTION
**Ticket:**
https://mhclgdigital.atlassian.net/browse/FLS-1422

**Description:**
This PR ensures that visited links are displayed in purple, allowing users to easily identify pages they have already visited within the application. The recent accessibility audit highlighted that this feature has not been available in FAB until now. 
As per Nima's instructions on the ticket, this change will apply only to certain links, with no changes required on the Home page.

**Screenshots:**
<img width="1022" height="787" alt="Screenshot 2025-08-29 at 11 18 36" src="https://github.com/user-attachments/assets/f6342c9c-121f-4be6-8215-f8859d3d3395" />

<img width="1070" height="736" alt="Screenshot 2025-08-29 at 11 18 54" src="https://github.com/user-attachments/assets/cad1584e-df61-4de3-8181-9102fbac1c1d" />

<img width="1011" height="661" alt="Screenshot 2025-08-29 at 11 21 45" src="https://github.com/user-attachments/assets/d1d888e8-74fa-4ffb-bd79-0058914b9b9d" />

<img width="1025" height="718" alt="Screenshot 2025-08-29 at 11 19 16" src="https://github.com/user-attachments/assets/3e9e0693-c9b1-45ea-951b-21cd714cb0ad" />

<img width="1086" height="1083" alt="Screenshot 2025-08-29 at 11 19 49" src="https://github.com/user-attachments/assets/77ef8687-6457-4cb1-b0ce-420b73f8c5bb" />

<img width="1025" height="908" alt="Screenshot 2025-08-29 at 11 25 26" src="https://github.com/user-attachments/assets/3d3c6de6-a3a3-41e2-9fa9-9792b87a48a8" />

<img width="1046" height="734" alt="Screenshot 2025-08-29 at 11 21 12" src="https://github.com/user-attachments/assets/d11c006b-767a-4f25-afe9-d5a813b38ac1" />

No changes have been made to links on the Home page:
<img width="1029" height="699" alt="Screenshot 2025-08-29 at 11 18 17" src="https://github.com/user-attachments/assets/ffa6543b-4cc9-44ed-b903-74f2379032a2" />
