### PR TITLE
Bugfix - strip leading numbers

### DIFF
--- a/app/all_questions/read_forms.py
+++ b/app/all_questions/read_forms.py
@@ -1,3 +1,6 @@
+import re
+
+
 def determine_display_value_for_condition(
     condition_value: str,
     list_name: str = None,
@@ -89,13 +92,7 @@ def strip_leading_numbers(text: str) -> str:
     Returns:
         str: Stripped string, eg. `A Title`
     """
-    result = text
-    for char in text:
-        if char == " ":
-            break
-        if char.isdigit() or char == ".":
-            result = result[1:]  # strip this character
-    return result.strip()
+    return re.sub(r"^[\d.\s]+", "", text).strip()
 
 
 def build_section_header(section_title, lang: str = "en"):

--- a/tests/unit/app/all_questions/test_read_forms.py
+++ b/tests/unit/app/all_questions/test_read_forms.py
@@ -1,0 +1,16 @@
+import pytest
+
+from app.all_questions.read_forms import strip_leading_numbers
+
+
+@pytest.mark.parametrize(
+    "input,expected_output",
+    [
+        ("1. Section", "Section"),
+        ("1.1.Section", "Section"),
+        ("Section 1.1", "Section 1.1"),
+        ("1 Sect1on 1", "Sect1on 1"),
+    ],
+)
+def test_strip_leading_numbers(input: str, expected_output: str):
+    assert strip_leading_numbers(input) == expected_output


### PR DESCRIPTION
This function was faulty. If for example you had a section name 'Section1', it would iterate over all of the characters, see the '1' at the end, and then lop the first character from the start of the string (the 'S'), giving 'ection1'. Not ideal!

The consequences of this function being broken? It was only used in 'view questions' HTML pages, and from inspecting the data in production, we can see that we've fortunately not had any section names that have included digits or full stops after the initial prefix, so this will have had no effect on users.