### PR TITLE
Bugfix - all questions view for individual forms

### DIFF
--- a/app/blueprints/application/routes.py
+++ b/app/blueprints/application/routes.py
@@ -290,14 +290,12 @@ def view_form_questions(round_id, section_id, form_id):
     round = get_round_by_id(round_id)
     fund = get_fund_by_id(round.fund_id)
     form = get_form_by_id(form_id=form_id)
-    start_page = next((p for p in form["pages"] if p["controller"] and p["controller"].endswith("start.js")), None)
     section_data = [
         {
-            "section_title": f"Preview of form [{form.name_in_apply_json['en']}]",
+            "section_title": "",  # Not used
             "forms": [{"name": form.runner_publish_name, "form_data": form.form_json}],
         }
     ]
-
     print_data = generate_print_data_for_sections(
         section_data,
         lang="en",
@@ -308,6 +306,6 @@ def view_form_questions(round_id, section_id, form_id):
         round=round,
         fund=fund,
         question_html=html,
-        title=start_page.name_in_apply_json["en"],
+        title=f"Preview of form [{form.name_in_apply_json['en']}]",
         all_questions_view=False,
     )


### PR DESCRIPTION
### 📓 Description

This is the 'View questions' action that appears alongside each form on the 'Build / view application' page. Currently it is broken and always causes an internal server error. This is because it tries to find the start page of a form by accessing the SQLAlchemy model Form as if it were a dict containing the form JSON, and even if we fix that, it wrongly expects every form page to have a 'controller' attribute. We don't actually need to find the start page at all as it turns out - we can just use the form name for the header text on the page.

### 📸 Screenshot

<img width="1916" height="969" alt="image" src="https://github.com/user-attachments/assets/35474df1-c3e2-4dfc-94f3-5fa1717e9e8a" />