### PR TITLE
Update SENTRY_DSN in manifest.yml

### DIFF
--- a/copilot/fsd-fund-application-builder/manifest.yml
+++ b/copilot/fsd-fund-application-builder/manifest.yml
@@ -49,7 +49,7 @@ variables:
   FLASK_ENV: ${COPILOT_ENVIRONMENT_NAME}
   NOTIFICATION_SERVICE_HOST: http://fsd-notification:8080
   MAINTENANCE_MODE: false
-  SENTRY_DSN: https://4128cfd691c439577e8f106968217f72@o1432034.ingest.us.sentry.io/4508496706666497
+  SENTRY_DSN: https://7c437f61cb15062ad2dc4ee2096af679@o4510940714041344.ingest.de.sentry.io/4511038199627856
   SENTRY_TRACES_SAMPLE_RATE: 0.02
   FORM_RUNNER_EXTERNAL_HOST: "https://application-questions.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
   FORM_DESIGNER_EXTERNAL_HOST: "https://form-designer.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"


### PR DESCRIPTION
Update Sentry DSN to point to the new MHCLG enterprise Sentry org. We are migrating all Funding Service projects from our legacy US-region Sentry org to the new EU-region org as part of the department-wide enterprise migration. No functional changes - this just switches where error events are sent.

https://mhclgdigital.atlassian.net/browse/FSPT-1199