### PR TITLE
BAU: Move workflow input to env var

### DIFF
--- a/.github/workflows/test_e2e_aws.yml
+++ b/.github/workflows/test_e2e_aws.yml
@@ -44,7 +44,8 @@ jobs:
           role-session-name: COPILOT_${{ inputs.environment }}_FAB_${{ steps.currentdatetime.outputs.datetime }}
           aws-region: eu-west-2
       - name: Run tests
-        run: uv run --frozen pytest --e2e --e2e-env ${{ inputs.environment }}
+        run: uv run --frozen pytest --e2e --e2e-env "$E2E_ENVIRONMENT"
         env:
+          E2E_ENVIRONMENT: ${{ inputs.environment }}
           E2E_DEVTEST_BASIC_AUTH_USERNAME: ${{ secrets.E2E_DEVTEST_BASIC_AUTH_USERNAME }}
           E2E_DEVTEST_BASIC_AUTH_PASSWORD: ${{ secrets.E2E_DEVTEST_BASIC_AUTH_PASSWORD }}


### PR DESCRIPTION
BAU - In line with best practice, use an env var in GitHub workflows rather than direct use of the string input.