### PR TITLE
BAU: Fix uv caching cleanup bug in workflows

### DIFF
--- a/.github/workflows/test_e2e_aws.yml
+++ b/.github/workflows/test_e2e_aws.yml
@@ -32,6 +32,7 @@ jobs:
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
+          prune-cache: false
       - name: Get current date
         shell: bash
         id: currentdatetime

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -51,6 +51,7 @@ jobs:
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
+          prune-cache: false
       - name: Save expected migration head
         run: echo "EXPECTED_HEAD=$(cat app/db/migrations/.current-alembic-head)" >> $GITHUB_ENV
       - name: Apply Database Migrations


### PR DESCRIPTION
There seems to be a known post-job cache-pruning bug with uv setup, specifically when running inside a container like the microsoft one we have it in here.

Common fix seems to be disabling the cache clean-up, which for a legacy repo seems like an OK low-effort fix in order to unblock the pipeline.